### PR TITLE
chore: install Base reuse adoption manifest

### DIFF
--- a/docs/base-reuse-adoption.json
+++ b/docs/base-reuse-adoption.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "base_source_commit": "8553678f70e22f193a2336b591f677dcfa5a8965",
+  "modules": {
+    "RM-TOOL-001": {"state": "planned"},
+    "RM-SYS-001": {"state": "not_applicable"},
+    "RM-SYS-003": {"state": "not_applicable"},
+    "RM-VIS-001": {
+      "state": "enabled",
+      "source": "templates/reuse-modules/godot/semantic_ui_skin_kit.gd",
+      "destination": "scripts/base_reuse/semantic_ui_skin_kit.gd"
+    },
+    "RM-VIS-002": {
+      "state": "enabled",
+      "source": "templates/reuse-modules/godot/gameplay_symbol_atlas.gd",
+      "destination": "scripts/base_reuse/gameplay_symbol_atlas.gd"
+    }
+  }
+}


### PR DESCRIPTION
## Goal
Install the Base reusable-module adoption manifest in My Little Boat without changing gameplay, scenes, controls, assets, project settings, or adding combat/failure/online systems.

## Profile
- RM-TOOL-001: planned
- RM-SYS-001: not_applicable
- RM-SYS-003: not_applicable
- RM-VIS-001: enabled for future `scripts/base_reuse/semantic_ui_skin_kit.gd`
- RM-VIS-002: enabled for future `scripts/base_reuse/gameplay_symbol_atlas.gd`

## Verification
This repository has no current GitHub Actions runtime path, so no Godot/runtime PASS is claimed.

Static readback verified that project `docs/base-reuse-adoption.json` is byte-identical to Base main `docs/knowledge/game-development/reuse/adoption/profiles/MY_LITTLE_BOAT.json`:
- project blob SHA: `a449498ad9bcc53a20690d4e6f53279d6cc78e64`
- Base profile blob SHA: `a449498ad9bcc53a20690d4e6f53279d6cc78e64`

Current main remains `90d176aa496786f43e7a11c14e9482efed0b1a27`; unresolved review threads 0.

## Boundary
Manifest installation only. The two GDScript helpers are not vendored yet because project-level runtime evidence is not available in this bounded change. No paid service, plugin, dependency, combat/failure system, or `project.godot` change.

Squash merge only if exact head remains `0b9aed0e6d5f08cc75ae0312b6d99479ae7005e8`.