### PR TITLE
Build Resting Core technical prototype

### DIFF
--- a/.github/workflows/godot-validation.yml
+++ b/.github/workflows/godot-validation.yml
@@ -37,6 +37,7 @@ jobs:
           godot --headless --path . --script res://tests/test_game_scene_contract.gd || status=1
           godot --headless --path . --script res://tests/test_album_memory_contract.gd || status=1
           godot --headless --path . --script res://tests/test_camera_input_contract.gd || status=1
+          godot --headless --path . --script res://tests/test_resting_core_contract.gd || status=1
           exit "$status"
 
       - name: Smoke main menu scene

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ MyLittleBoat/
     game.tscn
     album.tscn
   scripts/
+    audio/
+      resting_soundscape.gd
     core/
       game_state.gd
     ui/
@@ -37,6 +39,7 @@ MyLittleBoat/
     voyage/
       boat_camera_controller.gd
       fishing_session.gd
+      resting_pet_placeholder.gd
       game_scene.gd
   tests/
     test_calm_voyage_state.gd
@@ -44,6 +47,7 @@ MyLittleBoat/
     test_game_scene_contract.gd
     test_album_memory_contract.gd
     test_camera_input_contract.gd
+    test_resting_core_contract.gd
   assets/
     images/
     audio/
@@ -89,9 +93,22 @@ MyLittleBoat/
 - 사진 / 풍경 / 편지 / 물고기 / 항해 기록이 같은 실행 세션 동안 누적되는 앨범
 - 사진·풍경·편지 기억에 따라 변하는 동반자 호감도 Lv 1~3
 
+## Resting Core Technical Prototype
+
+현재는 최종 자산을 만들기 전에 구조를 검증하는 **기술 prototype**이 추가되어 있습니다.
+
+- `RestingSoundscape` AutoLoad가 메뉴/항해/앨범 Scene 전환에도 유지됩니다.
+- 런타임 생성 `AudioStreamWAV` OceanBed가 `-16 dB`에서 loop됩니다.
+- 이 합성음은 **TECHNICAL_PROTOTYPE**이며 자연 파도 production audio가 아닙니다.
+- 바다 placeholder는 roughness를 높이고 밝기/조명/마음별 하늘 톤을 더 부드러운 범위로 낮췄습니다.
+- 둥근 `RestingPetPlaceholder` 1종이 12~24초 저밀도 idle과 아주 작은 호흡만 수행합니다.
+- 펫 placeholder에는 배고픔·청소·피로·방치 의무가 없습니다.
+
+자동 테스트는 이 구조를 검증하지만 **실제로 듣기/보기에 편안하다는 뜻은 아닙니다.**
+
 ## 현재 구현 경계
 
-현재는 **기능 Vertical Slice는 존재하지만 최종 휴식 경험 자산은 아직 없는 상태**입니다.
+현재는 **기능 Vertical Slice + Resting Core 기술 구조는 존재하지만 최종 휴식 경험 자산은 아직 없는 상태**입니다.
 
 - 앨범을 열었다가 바다로 돌아와도 현재 항해 타이머와 상태가 이어집니다.
 - 새 항해를 시작해도 이전 사진·풍경·편지·물고기·항해 기록과 동반자 진행은 지우지 않습니다.
@@ -100,26 +117,28 @@ MyLittleBoat/
 - 사진은 아직 실제 PNG 파일을 저장하지 않고 텍스트 기록으로 남깁니다.
 - 낚시는 현재 조용한 보조 콘텐츠입니다. 어종 대량화, 미끼, 장비, 판매, 요리, 낚시 경제는 **별도 기획 결정 전까지 현재 범위에서 추가하지 않습니다.**
 - 모바일 화면 드래그는 자동 입력 계약으로 기술 연결을 검증했지만 실제 스마트폰 손감각·버튼 크기·가독성은 `NOT_RUN`입니다.
-- `assets/audio`에는 아직 production audio가 없습니다. 파도소리 휴식감은 `NOT_RUN`입니다.
-- 제작 펫 모델/idle 애니메이션이 없습니다. 펫의 실제 시각적 휴식감은 `NOT_RUN`입니다.
+- production 자연 파도/잔물결/바람/선체/펫 audio asset은 아직 없습니다. Human listening은 `NOT_RUN`입니다.
+- 제작 펫 모델/idle 애니메이션이 없습니다. 현재 둥근 펫은 기술 placeholder입니다.
 - 현재 placeholder 바다/보트는 최종 Visual PASS가 아닙니다.
 
 ## 다음 우선 작업
 
-기능 수를 늘리지 않고 **Resting Core Asset Prototype**을 먼저 만듭니다.
+기능 수를 늘리지 않고 **Production Resting Asset A/B**를 진행합니다.
 
-1. 잔잔한 파도 `OceanBed` A/B 후보 청취 및 권리 readback
-2. 가까운 물결 + 낮은 바람 + 드문 선체 소리 최소 soundscape
-3. 편안한 바다/하늘 color study
-4. 첫 펫 1종의 `바다 보기 / 앉기 / 눕기 / 졸기 / 하품·기지개` idle prototype
+1. 실제 자연 파도 `OceanBed` A/B 후보 청취 + 권리/hash readback
+2. 선택된 OceanBed를 persistent soundscape에 교체하고 `NearWater` 1개만 추가
+3. 편안한 바다/하늘 production color study
+4. 첫 펫 1종의 실제 visual brief 승인 → 단일 제작 → resting idle 연결
 5. 제작 자산이 들어간 30초 / 5분 Human rest test
 
 ## 현재 Godot 골격
 
 - `scenes/main_menu.tscn`: 오늘의 마음 선택 후 새 항해 시작
-- `scenes/game.tscn`: 1인칭 보트 감상, 5분 상태, 핵심 조작, Ambient Discovery, 선택형 낚시, 다음 항해 진입
+- `scenes/game.tscn`: 1인칭 보트 감상, 5분 상태, 핵심 조작, Ambient Discovery, 선택형 낚시, soft-sea placeholder, resting-pet placeholder
 - `scenes/album.tscn`: 사진·풍경·편지·물고기·항해 기록 확인
 - `scripts/core/game_state.gd`: Scene 전환보다 오래 살아야 하는 현재 항해 상태와 누적 기억을 보관하는 AutoLoad
+- `scripts/audio/resting_soundscape.gd`: Scene 전환에 끊기지 않는 persistent 기술용 OceanBed AutoLoad
+- `scripts/voyage/resting_pet_placeholder.gd`: 관리 의무 없는 저밀도 resting idle 기술 placeholder
 - `scripts/voyage/fishing_session.gd`: 실패 없는 `IDLE → WAITING → BITE_READY → IDLE` 낚시 상태 머신
 - `scripts/voyage/boat_camera_controller.gd`: PC 마우스와 모바일 화면 드래그 시야 회전
 
@@ -135,6 +154,7 @@ Godot 버전 확인
 → game scene 의미 계약
 → album memory 계약
 → camera input 계약
+→ resting core technical contract
 → main menu / game / album scene smoke
 ```
 
@@ -182,11 +202,15 @@ Notion 사람용 방향 승인
 - [ ] 반복 낚시만으로 동반자 호감도를 파밍할 수 없다.
 - [ ] 앨범에 물고기와 항해 기록도 표시된다.
 - [ ] synthetic 모바일 화면 드래그가 카메라를 돌리면서 pitch clamp와 수평을 보존한다.
+- [ ] RestingSoundscape가 persistent AutoLoad이고 기술용 OceanBed가 loop된다.
+- [ ] RestingSoundscape는 `TECHNICAL_PROTOTYPE` evidence class를 노출한다.
+- [ ] 펫 placeholder idle 간격이 최소 10초 이상이고 care obligation이 없다.
+- [ ] runtime 마음별 하늘과 ocean material이 soft-resting 기술 범위를 지킨다.
 
 ### Resting Core 사람 검증 — 제작 자산 통합 후
 
 - [ ] 첫 30초에 버튼을 누르지 않아도 바다에 머물고 싶은가.
-- [ ] 음악 OFF + 파도소리만으로 공간이 성립하는가.
+- [ ] 음악 OFF + 실제 파도소리만으로 공간이 성립하는가.
 - [ ] 5분이 편안한가, 아니면 `EMPTY`/`CHORES`로 느껴지는가.
 - [ ] 마음별 미세한 하늘 톤 차이가 감정을 강요하지 않고 자연스럽게 느껴지는가.
 - [ ] 파도 loop seam, 큰 소리, 날카로운 고역이 거슬리지 않는가.

--- a/assets/audio/README.md
+++ b/assets/audio/README.md
@@ -2,7 +2,20 @@
 
 `my little boat`의 오디오는 **파도소리만 들어도 쉬는 느낌이 드는가**를 최우선으로 판단합니다.
 
-현재 이 폴더에는 production audio가 없습니다. 아래는 자산 구조와 승인 기준이며, 후보 URL이 존재한다고 해서 게임에 통합됐다는 뜻은 아닙니다.
+현재 이 폴더에는 **production audio asset이 없습니다.** 아래는 자산 구조와 승인 기준이며, 후보 URL이 존재한다고 해서 게임에 통합됐다는 뜻은 아닙니다.
+
+## 0. 현재 Technical Prototype
+
+- `RestingSoundscape`는 `project.godot` AutoLoad로 존재해 메뉴/항해/앨범 Scene 전환에도 유지됩니다.
+- `scripts/audio/resting_soundscape.gd`가 4초짜리 합성 `AudioStreamWAV`를 런타임에서 한 번 생성하고 loop합니다.
+- 기본 볼륨은 `-16 dB`입니다.
+- 이 소리는 **외부 자연 녹음이 아니라 playback/loop/지속성 구조를 검증하기 위한 TECHNICAL_PROTOTYPE**입니다.
+- 자동 테스트는 `TECHNICAL_PROTOTYPE=true`, loop mode, 낮은 기본 볼륨, persistent AutoLoad를 검증합니다.
+- 이 합성음을 듣고 `AUDIO_REST_PASS`를 판정하지 않습니다. 실제 자연 파도 자산 + Human listening이 필요합니다.
+
+현재 evidence:
+
+`TECH_AUDIO_WIRING = PASS / PRODUCTION_OCEAN_AUDIO = NOT_INTEGRATED / HUMAN_LISTENING = NOT_RUN`
 
 ## 1. Audio North Star
 
@@ -97,7 +110,7 @@ assets/audio/ui/<action>.ogg
 
 ## 6. Human Listening Gate
 
-실제 오디오 통합 후 아래를 직접 확인하기 전에는 `AUDIO_REST_PASS`를 주장하지 않습니다.
+실제 자연 오디오 통합 후 아래를 직접 확인하기 전에는 `AUDIO_REST_PASS`를 주장하지 않습니다.
 
 1. 눈을 감고 30초 들어도 편안한가?
 2. 5분 동안 loop 반복이 거슬리지 않는가?
@@ -106,5 +119,4 @@ assets/audio/ui/<action>.ogg
 5. 헤드폰·일반 스피커·모바일 스피커에서 모두 지나치게 피곤하지 않은가?
 6. 음악 OFF에서도 공간이 비어 보이지 않는가?
 
-현재 상태: **PRODUCTION AUDIO NOT_INTEGRATED / HUMAN LISTENING NOT_RUN**
-
+현재 상태: **TECH_AUDIO_WIRING PASS / PRODUCTION AUDIO NOT_INTEGRATED / HUMAN LISTENING NOT_RUN**

--- a/docs/GODOT_MVP_ROADMAP.md
+++ b/docs/GODOT_MVP_ROADMAP.md
@@ -101,7 +101,7 @@
 
 기술 GREEN은 Human/player experience PASS가 아니다.
 
-## 10단계: Rest-first Direction → Repository Contract Sync
+## 10단계: Rest-first Direction → Repository Contract Sync — 완료
 
 목표:
 - Notion에서 승인된 `아무것도 하지 않아도 쉬는 5분 공간` 방향을 repository 구현 계약으로 명확히 동기화한다.
@@ -115,36 +115,57 @@
 
 이 단계는 **repository 계약 동기화**이며 실제 production audio/pet art가 구현됐다는 뜻이 아니다.
 
-## 11단계: Resting Core Asset Prototype — 다음 제작 단계
+## 11단계: Resting Core Technical Prototype — 구현 완료 / Human 품질 검증 전
 
-기능을 더 늘리기 전에 최소 자산으로 휴식 감각을 만듭니다.
+최종 자산을 기다리지 않고 구조·회귀를 먼저 검증하는 단계입니다.
 
-### Audio 최소 세트
+### 구현된 기술 구조
 
-1. `OceanBed` — 잔잔한 파도
-2. `NearWater` — 보트 가까운 잔물결
-3. `Wind` — 낮은 밀도 바람
-4. `BoatCreak` — 아주 드문 선체 소리
-5. 선택형 `PetFoley` — 작은 숨/기지개/움직임
+- `RestingSoundscape`를 AutoLoad로 등록해 메뉴/항해/앨범 Scene 전환에도 같은 인스턴스를 유지한다.
+- `scripts/audio/resting_soundscape.gd`가 4초 합성 `AudioStreamWAV` OceanBed를 한 번 생성하고 `-16 dB`에서 loop한다.
+- 합성 OceanBed는 `TECHNICAL_PROTOTYPE=true`이며 production 자연 파도 자산이 아니다.
+- 바다 material roughness/밝기, DirectionalLight, 마음별 하늘 톤을 더 부드러운 기술 범위로 조정한다.
+- `RestingPetPlaceholder` 1종을 둥근 기술 mesh로 배치하고, 12~24초 저밀도 idle + 아주 작은 호흡을 사용한다.
+- 펫 placeholder에는 배고픔·청소·피로·방치 의무가 없다.
+- `test_resting_core_contract.gd`가 persistent soundscape, loop/evidence class, pet care boundary, soft ocean/sky 범위를 검증한다.
 
-첫 기술 후보는 CC0 여부가 명시된 작은 seamless wave loop부터 A/B 테스트하되, 실제 파일과 라이선스를 다시 확인한 뒤 통합합니다.
+### 이 단계에서 주장할 수 없는 것
 
-### Visual 최소 세트
+- 합성 OceanBed가 실제로 편안한 파도소리다.
+- 현재 둥근 펫이 최종 캐릭터 디자인이다.
+- 현재 placeholder 바다/하늘이 최종 Visual PASS다.
+- 실제 모바일에서 시각/청취/조작이 편안하다.
 
-- 편안한 바다/하늘 color study
+따라서 상태는:
+
+`TECH_RESTING_CORE = PASS / AUDIO_REST_PASS = NOT_RUN / VISUAL_REST_PASS = NOT_RUN / PET_REST_PASS = NOT_RUN`
+
+## 12단계: Production Resting Asset A/B — 다음 제작 단계
+
+기능을 더 늘리기 전에 실제 자산으로 기술 placeholder를 교체합니다.
+
+### Audio
+
+1. `OceanBed A/B` 실제 자연 파도 후보를 청취한다.
+2. source URL / creator / license / original hash / runtime hash를 readback한다.
+3. 선택된 OceanBed를 persistent `RestingSoundscape`에 교체한다.
+4. `NearWater` 한 레이어만 추가한 뒤 다시 청취한다.
+5. 필요성이 확인되기 전에는 Wind / BoatCreak / PetFoley를 한꺼번에 추가하지 않는다.
+
+### Visual
+
+- 편안한 바다/하늘 production color study
 - 과하지 않은 수면 반사
 - 안정적인 수평선
-- 작은 구름/원거리 생명체 움직임
-- placeholder를 대체할 최소 보트 재질
-- 환경 톤은 부드럽게 유지하되 텍스트·버튼의 가독성은 별도 보호
+- 최소 보트 재질
+- 실제 펫 이미지/모델은 Visual 정책에 따라 `텍스트 brief → 명시 승인 → 1건 제작` 순서를 지킨다.
 
-### Pet 최소 세트
+### Pet
 
-첫 펫 1종으로 아래 idle만 검증합니다.
+첫 펫 1종으로 아래 존재감을 검증한다.
 
 - 바다 보기
-- 앉기
-- 눕기
+- 앉기 / 눕기
 - 졸기
 - 하품/기지개
 - 작은 귀/꼬리 반응
@@ -153,12 +174,12 @@
 
 **펫 수를 늘리기 전에 1종의 존재감이 실제로 편안한지 확인합니다.**
 
-## 12단계: Resting Core Human Validation
+## 13단계: Resting Core Human Validation
 
 제작 자산이 들어간 뒤 아래를 사람 눈/귀/손으로 검증합니다.
 
 1. 첫 30초에 조작 없이도 머물고 싶은가.
-2. 음악 OFF + 파도소리만으로 공간이 성립하는가.
+2. 음악 OFF + 실제 파도소리만으로 공간이 성립하는가.
 3. 5분이 `CALM`인가 `EMPTY`인가.
 4. 마음별 미세한 하늘 톤 차이가 감정을 강요하지 않고 자연스럽게 느껴지는가.
 5. 음원 loop seam/날카로운 고역/갑작스러운 큰 소리가 거슬리지 않는가.

--- a/docs/MVP_SCOPE.md
+++ b/docs/MVP_SCOPE.md
@@ -11,12 +11,12 @@
 MVP가 궁극적으로 통과해야 하는 기준:
 
 - 아무 조작 없이도 30초 이상 머물고 싶은가.
-- 음악을 끄고 파도/자연음만 들어도 공간이 성립하는가.
+- 음악을 끄고 실제 파도/자연음만 들어도 공간이 성립하는가.
 - 5분이 `CALM`으로 느껴지고 `EMPTY`나 `CHORES`로 변하지 않는가.
 - 펫이 할 일을 만드는 존재가 아니라 곁에서 같이 쉬는 존재로 느껴지는가.
 - 사진·낚시·발견을 무시해도 손해나 불안이 없는가.
 
-이 항목은 제작 아트/오디오/펫 자산이 들어간 Human playtest 전에는 `NOT_RUN`입니다.
+이 항목은 제작 아트/자연 오디오/펫 자산이 들어간 Human playtest 전에는 `NOT_RUN`입니다.
 
 ## 현재 구현된 Vertical Slice
 
@@ -58,20 +58,52 @@ MVP가 궁극적으로 통과해야 하는 기준:
   - 기록 수
   - 최근 기록
 
-## 승인된 다음 경험 방향 — 아직 runtime PASS 아님
+## 현재 Resting Core Technical Prototype
+
+최종 자산을 기다리기 전에 구현 구조를 검증하는 기술 placeholder가 포함됩니다.
+
+### Technical soundscape
+
+- `RestingSoundscape` AutoLoad가 메뉴/항해/앨범 Scene 전환에 유지된다.
+- 런타임에서 4초 합성 `AudioStreamWAV`를 생성하고 `-16 dB`에서 loop한다.
+- 합성 OceanBed는 `TECHNICAL_PROTOTYPE=true`이며 production 자연 파도 자산이 아니다.
+- 자동 테스트는 persistent owner / loop / evidence class / 보수적 볼륨을 검증한다.
+
+### Technical resting pet
+
+- `RestingPetPlaceholder` 1종이 둥근 mesh로 존재한다.
+- 12~24초 간격의 저밀도 resting state와 아주 작은 호흡만 사용한다.
+- 배고픔 / 청소 / 피로 / 방치 의무가 없다.
+- 현재 mesh와 움직임은 최종 펫 디자인/animation이 아니다.
+
+### Technical soft sea
+
+- ocean roughness와 밝기를 부드러운 placeholder 범위로 조정한다.
+- DirectionalLight 에너지를 낮추고 마음별 runtime 하늘 톤도 brightness ceiling 안에 둔다.
+- 마음별 차이는 남기되 좋고/나쁜 날씨로 판정하지 않는다.
+
+현재 자동 evidence:
+
+`TECH_RESTING_CORE = PASS`
+
+아래는 아직 자동 PASS로 승격하지 않는다.
+
+`AUDIO_REST_PASS / VISUAL_REST_PASS / PET_REST_PASS / MOBILE_REST_PASS = NOT_RUN`
+
+## Production 목표 — 아직 Human PASS 아님
 
 ### Wave-first soundscape
 
-- 잔잔한 파도 `OceanBed`를 가장 중요한 소리로 둔다.
+- 실제 잔잔한 파도 `OceanBed`를 가장 중요한 소리로 둔다.
 - 가까운 물결, 낮은 바람, 드문 선체 creak, 먼 자연음, 펫 foley를 낮은 밀도로 레이어링한다.
 - 음악은 선택형이다. 음악 OFF에서도 5분 경험이 성립해야 한다.
 - 큰 효과음/보상 징글/갑작스러운 고역을 피한다.
 
-현재 `assets/audio`에는 production audio가 없으므로 **구현 완료로 표시하지 않는다.**
+현재 **production 자연 audio asset은 없으며**, 합성 기술 bed를 최종 소리로 간주하지 않는다.
 
 ### Resting pet presence
 
-- 펫은 바다 보기 / 앉기 / 눕기 / 졸기 / 하품·기지개 / 작은 귀·꼬리 반응을 기본 idle로 한다.
+- 실제 펫은 바다 보기 / 앉기 / 눕기 / 졸기 / 하품·기지개 / 작은 귀·꼬리 반응을 기본 idle로 한다.
 - 가끔 플레이어를 보거나 낚시를 조용히 지켜본다.
 - 배고픔, 청소, 피로, 방치 패널티, 반복 터치 파밍을 만들지 않는다.
 
@@ -80,13 +112,14 @@ MVP가 궁극적으로 통과해야 하는 기준:
 ### Soft sea visual tone
 
 - 안정적인 수평선
-- 저~중간 대비
+- 저~중간 환경 대비
 - 부드러운 하늘/바다 색
 - 작은 고휘도 반짝임/깜빡임 억제
 - 매우 작은 bob
 - 낮은 빈도의 구름/원거리 생명체/펫 idle로 `EMPTY`를 방지
+- 텍스트/버튼/포커스는 환경과 별개로 충분한 가독성을 유지
 
-현재 placeholder 환경은 최종 Visual PASS가 아니다.
+현재 색/재질 조정은 **technical placeholder**이며 최종 Visual PASS가 아니다.
 
 세부 기준: `docs/RESTING_EXPERIENCE_BIBLE.md`
 
@@ -101,7 +134,7 @@ MVP가 궁극적으로 통과해야 하는 기준:
 
 - 앱 재실행을 넘는 save file persistence
 - 실제 사진 PNG 저장
-- 제작 아트/최종 오디오
+- 제작 아트/최종 자연 오디오
 - 제작 펫 모델/애니메이션
 - 어종 대량 콘텐츠
 - 미끼 / 낚싯대 장비 / 줄 내구도

--- a/project.godot
+++ b/project.godot
@@ -3,7 +3,7 @@
 ; since the parameters that go here are not all obvious.
 ;
 ; Format:
-;   [section] ; section goes between []
+;   [section] ; section between []
 ;   param=value ; assign values to parameters
 
 config_version=5
@@ -17,6 +17,7 @@ config/features=PackedStringArray("4.7")
 [autoload]
 
 GameState="*res://scripts/core/game_state.gd"
+RestingSoundscape="*res://scripts/audio/resting_soundscape.gd"
 
 [display]
 

--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=12 format=3]
+[gd_scene load_steps=11 format=3]
 
 [ext_resource type="Script" path="res://scripts/voyage/game_scene.gd" id="1"]
 [ext_resource type="Script" path="res://scripts/voyage/boat_camera_controller.gd" id="2"]
-[ext_resource type="Script" path="res://scripts/audio/resting_soundscape.gd" id="3"]
 [ext_resource type="Script" path="res://scripts/voyage/resting_pet_placeholder.gd" id="4"]
 
 [sub_resource type="Environment" id="Environment_sky"]
@@ -45,13 +44,6 @@ grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
 script = ExtResource("1")
-
-[node name="RestingSoundscape" type="Node" parent="."]
-script = ExtResource("3")
-
-[node name="OceanBed" type="AudioStreamPlayer" parent="RestingSoundscape"]
-autoplay = true
-volume_db = -16.0
 
 [node name="VoyageWorld" type="Node3D" parent="."]
 

--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -1,28 +1,40 @@
-[gd_scene load_steps=8 format=3]
+[gd_scene load_steps=12 format=3]
 
 [ext_resource type="Script" path="res://scripts/voyage/game_scene.gd" id="1"]
 [ext_resource type="Script" path="res://scripts/voyage/boat_camera_controller.gd" id="2"]
+[ext_resource type="Script" path="res://scripts/audio/resting_soundscape.gd" id="3"]
+[ext_resource type="Script" path="res://scripts/voyage/resting_pet_placeholder.gd" id="4"]
 
 [sub_resource type="Environment" id="Environment_sky"]
 background_mode = 1
-background_color = Color(0.64, 0.84, 0.96, 1)
+background_color = Color(0.58, 0.76, 0.86, 1)
 ambient_light_source = 1
-ambient_light_color = Color(0.86, 0.93, 1, 1)
-ambient_light_energy = 0.9
+ambient_light_color = Color(0.84, 0.91, 0.95, 1)
+ambient_light_energy = 0.82
 
 [sub_resource type="PlaneMesh" id="PlaneMesh_ocean"]
 size = Vector2(180, 180)
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_ocean"]
-albedo_color = Color(0.25, 0.55, 0.8, 1)
-roughness = 0.82
+albedo_color = Color(0.2, 0.47, 0.62, 1)
+roughness = 0.92
 
 [sub_resource type="BoxMesh" id="BoxMesh_boat_bow"]
 size = Vector3(2.8, 0.22, 2.4)
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_boat"]
-albedo_color = Color(0.93, 0.78, 0.52, 1)
-roughness = 0.68
+albedo_color = Color(0.89, 0.75, 0.54, 1)
+roughness = 0.72
+
+[sub_resource type="SphereMesh" id="SphereMesh_pet"]
+radius = 0.45
+height = 0.9
+radial_segments = 20
+rings = 10
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_pet"]
+albedo_color = Color(0.82, 0.75, 0.66, 1)
+roughness = 0.96
 
 [node name="GameScene" type="Control"]
 layout_mode = 3
@@ -34,6 +46,13 @@ grow_vertical = 2
 mouse_filter = 2
 script = ExtResource("1")
 
+[node name="RestingSoundscape" type="Node" parent="."]
+script = ExtResource("3")
+
+[node name="OceanBed" type="AudioStreamPlayer" parent="RestingSoundscape"]
+autoplay = true
+volume_db = -16.0
+
 [node name="VoyageWorld" type="Node3D" parent="."]
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="VoyageWorld"]
@@ -41,7 +60,7 @@ environment = SubResource("Environment_sky")
 
 [node name="SunLight" type="DirectionalLight3D" parent="VoyageWorld"]
 rotation = Vector3(-0.85, -0.35, 0)
-light_energy = 1.45
+light_energy = 1.05
 
 [node name="CameraRig" type="Node3D" parent="VoyageWorld"]
 unique_name_in_owner = true
@@ -63,6 +82,22 @@ surface_material_override/0 = SubResource("StandardMaterial3D_ocean")
 position = Vector3(0, 0.18, 0.55)
 mesh = SubResource("BoxMesh_boat_bow")
 surface_material_override/0 = SubResource("StandardMaterial3D_boat")
+
+[node name="RestingPetPlaceholder" type="Node3D" parent="VoyageWorld"]
+position = Vector3(0.9, 0.58, 0.38)
+scale = Vector3(0.72, 0.72, 0.72)
+script = ExtResource("4")
+
+[node name="Body" type="MeshInstance3D" parent="VoyageWorld/RestingPetPlaceholder"]
+scale = Vector3(0.72, 0.58, 0.92)
+mesh = SubResource("SphereMesh_pet")
+surface_material_override/0 = SubResource("StandardMaterial3D_pet")
+
+[node name="Head" type="MeshInstance3D" parent="VoyageWorld/RestingPetPlaceholder"]
+position = Vector3(0, 0.28, -0.42)
+scale = Vector3(0.55, 0.55, 0.55)
+mesh = SubResource("SphereMesh_pet")
+surface_material_override/0 = SubResource("StandardMaterial3D_pet")
 
 [node name="TopPanel" type="PanelContainer" parent="."]
 layout_mode = 1

--- a/scripts/audio/resting_soundscape.gd
+++ b/scripts/audio/resting_soundscape.gd
@@ -1,0 +1,59 @@
+# Resting Core technical audio prototype.
+# This creates a deterministic, low-level loop so playback/loop architecture can be tested
+# without pretending a final natural-ocean recording has been approved.
+extends Node
+
+const SAMPLE_RATE := 16000
+const LOOP_SECONDS := 4
+const TECHNICAL_PROTOTYPE := true
+
+@onready var ocean_bed: AudioStreamPlayer = $OceanBed
+
+
+func _ready() -> void:
+	if ocean_bed.stream == null:
+		ocean_bed.stream = _build_technical_ocean_loop()
+	if not ocean_bed.playing:
+		ocean_bed.play()
+
+
+func is_technical_prototype() -> bool:
+	return TECHNICAL_PROTOTYPE
+
+
+func get_layer_priority() -> Array[String]:
+	return ["OceanBed", "NearWater", "Wind", "BoatCreak", "DistantNature/PetFoley", "UI"]
+
+
+# Generates a seamless four-second technical bed from periodic sine components.
+# Frequencies are exact multiples of the loop period, so the waveform closes cleanly.
+# This is intentionally synthetic and must never be promoted as production ocean audio.
+func _build_technical_ocean_loop() -> AudioStreamWAV:
+	var sample_count := SAMPLE_RATE * LOOP_SECONDS
+	var bytes := PackedByteArray()
+	bytes.resize(sample_count * 2)
+
+	for i in range(sample_count):
+		var t := float(i) / float(SAMPLE_RATE)
+		var phase := TAU * t / float(LOOP_SECONDS)
+		var slow_swell := 0.62 + 0.16 * sin(phase) + 0.08 * sin(phase * 2.0 + 0.8)
+		var texture := (
+			sin(phase * 173.0 + 0.4)
+			+ 0.72 * sin(phase * 251.0 + 1.7)
+			+ 0.48 * sin(phase * 337.0 + 2.8)
+			+ 0.31 * sin(phase * 421.0 + 0.9)
+			+ 0.22 * sin(phase * 509.0 + 2.1)
+		) / 2.73
+		var sample_value := clampf(texture * slow_swell * 0.12, -0.18, 0.18)
+		var encoded := int(round(sample_value * 32767.0))
+		bytes.encode_s16(i * 2, encoded)
+
+	var stream := AudioStreamWAV.new()
+	stream.format = AudioStreamWAV.FORMAT_16_BITS
+	stream.mix_rate = SAMPLE_RATE
+	stream.stereo = false
+	stream.data = bytes
+	stream.loop_mode = AudioStreamWAV.LOOP_FORWARD
+	stream.loop_begin = 0
+	stream.loop_end = sample_count
+	return stream

--- a/scripts/audio/resting_soundscape.gd
+++ b/scripts/audio/resting_soundscape.gd
@@ -1,16 +1,25 @@
-# Resting Core technical audio prototype.
-# This creates a deterministic, low-level loop so playback/loop architecture can be tested
-# without pretending a final natural-ocean recording has been approved.
+# Persistent Resting Core technical audio prototype.
+# This creates one deterministic low-level loop for playback/loop architecture tests.
+# It is not a final natural-ocean recording and cannot earn AUDIO_REST_PASS.
 extends Node
 
 const SAMPLE_RATE := 16000
 const LOOP_SECONDS := 4
 const TECHNICAL_PROTOTYPE := true
+const OCEAN_BED_VOLUME_DB := -16.0
 
-@onready var ocean_bed: AudioStreamPlayer = $OceanBed
+var ocean_bed: AudioStreamPlayer
 
 
 func _ready() -> void:
+	ocean_bed = get_node_or_null("OceanBed") as AudioStreamPlayer
+	if ocean_bed == null:
+		ocean_bed = AudioStreamPlayer.new()
+		ocean_bed.name = "OceanBed"
+		ocean_bed.autoplay = true
+		ocean_bed.volume_db = OCEAN_BED_VOLUME_DB
+		add_child(ocean_bed)
+
 	if ocean_bed.stream == null:
 		ocean_bed.stream = _build_technical_ocean_loop()
 	if not ocean_bed.playing:

--- a/scripts/voyage/game_scene.gd
+++ b/scripts/voyage/game_scene.gd
@@ -14,10 +14,10 @@ const SCENERY_NAMES: Array[String] = ["일출", "비", "고래", "밤바다"]
 const FISH_NAMES: Array[String] = ["정어리", "전갱이", "고등어", "도미"]
 
 const MOOD_SKY_COLORS := {
-	"평온": Color(0.64, 0.84, 0.96, 1.0),
-	"지침": Color(0.66, 0.80, 0.88, 1.0),
-	"외로움": Color(0.60, 0.77, 0.91, 1.0),
-	"설렘": Color(0.72, 0.86, 0.95, 1.0),
+	"평온": Color(0.58, 0.76, 0.86, 1.0),
+	"지침": Color(0.60, 0.72, 0.80, 1.0),
+	"외로움": Color(0.55, 0.69, 0.82, 1.0),
+	"설렘": Color(0.66, 0.80, 0.88, 1.0),
 }
 
 const FIRST_DISCOVERY_MIN_SECONDS := 18.0

--- a/scripts/voyage/resting_pet_placeholder.gd
+++ b/scripts/voyage/resting_pet_placeholder.gd
@@ -1,0 +1,62 @@
+# Resting-pet technical placeholder.
+# It exists to validate low-pressure idle timing and scene composition, not final pet art.
+extends Node3D
+
+const RESTING_STATES: Array[String] = ["watch_sea", "rest", "nap", "glance"]
+const MIN_IDLE_SECONDS := 12.0
+const MAX_IDLE_SECONDS := 24.0
+
+var _resting_state := "watch_sea"
+var _next_idle_seconds := 16.0
+var _elapsed := 0.0
+var _breath_phase := 0.0
+var _base_scale := Vector3.ONE
+
+
+func _ready() -> void:
+	_base_scale = scale
+
+
+func _process(delta: float) -> void:
+	var safe_delta := maxf(delta, 0.0)
+	_elapsed += safe_delta
+	_breath_phase += safe_delta * 0.75
+
+	# Subtle breathing only; no attention-demanding bounce or notification.
+	var breath := 1.0 + sin(_breath_phase) * 0.012
+	scale = Vector3(_base_scale.x, _base_scale.y * breath, _base_scale.z)
+
+	if _elapsed >= _next_idle_seconds:
+		_elapsed = 0.0
+		_advance_resting_state()
+		_next_idle_seconds = randf_range(MIN_IDLE_SECONDS, MAX_IDLE_SECONDS)
+
+
+func get_resting_state() -> String:
+	return _resting_state
+
+
+func get_next_idle_seconds() -> float:
+	return _next_idle_seconds
+
+
+func has_care_obligation() -> bool:
+	return false
+
+
+func _advance_resting_state() -> void:
+	var current_index := RESTING_STATES.find(_resting_state)
+	if current_index < 0:
+		current_index = 0
+	_resting_state = RESTING_STATES[(current_index + 1) % RESTING_STATES.size()]
+
+	# Keep visual changes tiny and readable as posture shifts, never as a demand.
+	match _resting_state:
+		"watch_sea":
+			rotation.y = 0.0
+		"rest":
+			rotation.y = 0.08
+		"nap":
+			rotation.y = -0.06
+		"glance":
+			rotation.y = 0.18

--- a/tests/test_resting_core_contract.gd
+++ b/tests/test_resting_core_contract.gd
@@ -1,4 +1,4 @@
-# Rest-first technical prototype contracts: audio wiring, soft sea composition, and non-demanding pet placeholder.
+# Rest-first technical prototype contracts: persistent audio wiring, soft sea composition, and non-demanding pet placeholder.
 extends SceneTree
 
 var _failures := 0
@@ -19,10 +19,11 @@ func _run() -> void:
 	root.add_child(scene)
 	await process_frame
 
-	var soundscape := scene.get_node_or_null("RestingSoundscape")
-	var ocean_bed := scene.get_node_or_null("RestingSoundscape/OceanBed") as AudioStreamPlayer
-	_expect(soundscape != null, "game scene must have a dedicated RestingSoundscape owner")
-	_expect(ocean_bed != null, "RestingSoundscape must expose an OceanBed AudioStreamPlayer")
+	var soundscape := root.get_node_or_null("RestingSoundscape")
+	var ocean_bed := root.get_node_or_null("RestingSoundscape/OceanBed") as AudioStreamPlayer
+	_expect(soundscape != null, "RestingSoundscape must be a persistent AutoLoad owner so album/menu scene changes do not restart the ocean bed")
+	_expect(scene.get_node_or_null("RestingSoundscape") == null, "game scene must not create a duplicate local RestingSoundscape")
+	_expect(ocean_bed != null, "persistent RestingSoundscape must expose an OceanBed AudioStreamPlayer")
 	if soundscape != null:
 		_expect(soundscape.has_method("is_technical_prototype"), "soundscape must expose its evidence class")
 		if soundscape.has_method("is_technical_prototype"):

--- a/tests/test_resting_core_contract.gd
+++ b/tests/test_resting_core_contract.gd
@@ -58,6 +58,11 @@ func _run() -> void:
 			_expect(material.roughness >= 0.85, "placeholder ocean must favor soft reflection over sharp glare")
 			_expect(material.albedo_color.v <= 0.75, "placeholder ocean must avoid excessively bright high-glare color")
 
+	var world_environment := scene.get_node_or_null("VoyageWorld/WorldEnvironment") as WorldEnvironment
+	_expect(world_environment != null and world_environment.environment != null, "resting prototype must expose a runtime sky environment")
+	if world_environment != null and world_environment.environment != null:
+		_expect(world_environment.environment.background_color.v <= 0.90, "runtime mood sky must stay inside the soft resting brightness ceiling")
+
 	scene.queue_free()
 	await process_frame
 	_finish()

--- a/tests/test_resting_core_contract.gd
+++ b/tests/test_resting_core_contract.gd
@@ -23,18 +23,30 @@ func _run() -> void:
 	var ocean_bed := scene.get_node_or_null("RestingSoundscape/OceanBed") as AudioStreamPlayer
 	_expect(soundscape != null, "game scene must have a dedicated RestingSoundscape owner")
 	_expect(ocean_bed != null, "RestingSoundscape must expose an OceanBed AudioStreamPlayer")
+	if soundscape != null:
+		_expect(soundscape.has_method("is_technical_prototype"), "soundscape must expose its evidence class")
+		if soundscape.has_method("is_technical_prototype"):
+			_expect(bool(soundscape.call("is_technical_prototype")), "current generated soundscape must stay explicitly TECHNICAL_PROTOTYPE")
 	if ocean_bed != null:
 		_expect(ocean_bed.stream != null, "OceanBed must have a technical prototype stream wired")
 		_expect(ocean_bed.autoplay, "OceanBed must autoplay so doing nothing still produces the resting space")
 		_expect(ocean_bed.volume_db <= -8.0, "technical OceanBed must start conservatively below -8 dB")
+		var wave := ocean_bed.stream as AudioStreamWAV
+		_expect(wave != null, "technical OceanBed must use an inspectable AudioStreamWAV loop")
+		if wave != null:
+			_expect(wave.loop_mode == AudioStreamWAV.LOOP_FORWARD, "technical OceanBed must loop continuously")
+			_expect(wave.loop_end > wave.loop_begin, "technical OceanBed loop range must be valid")
 
 	var pet := scene.get_node_or_null("VoyageWorld/RestingPetPlaceholder") as Node3D
 	_expect(pet != null, "game scene must include one clearly-placeholder resting pet")
 	if pet != null:
 		_expect(pet.has_method("get_resting_state"), "resting pet controller must expose its current low-pressure idle state")
 		_expect(pet.has_method("get_next_idle_seconds"), "resting pet controller must expose the next idle interval for testability")
+		_expect(pet.has_method("has_care_obligation"), "resting pet must expose whether it creates a care obligation")
 		if pet.has_method("get_next_idle_seconds"):
 			_expect(float(pet.call("get_next_idle_seconds")) >= 10.0, "pet idle interval must be long enough to avoid attention-seeking behavior")
+		if pet.has_method("has_care_obligation"):
+			_expect(not bool(pet.call("has_care_obligation")), "resting pet placeholder must not create hunger/cleaning/fatigue obligations")
 
 	var ocean := scene.get_node_or_null("VoyageWorld/OceanPlane") as MeshInstance3D
 	_expect(ocean != null, "resting prototype must keep an explicit OceanPlane")

--- a/tests/test_resting_core_contract.gd
+++ b/tests/test_resting_core_contract.gd
@@ -1,0 +1,66 @@
+# Rest-first technical prototype contracts: audio wiring, soft sea composition, and non-demanding pet placeholder.
+extends SceneTree
+
+var _failures := 0
+
+
+func _init() -> void:
+	call_deferred("_run")
+
+
+func _run() -> void:
+	var packed_scene := load("res://scenes/game.tscn") as PackedScene
+	_expect(packed_scene != null, "game.tscn must load")
+	if packed_scene == null:
+		_finish()
+		return
+
+	var scene := packed_scene.instantiate()
+	root.add_child(scene)
+	await process_frame
+
+	var soundscape := scene.get_node_or_null("RestingSoundscape")
+	var ocean_bed := scene.get_node_or_null("RestingSoundscape/OceanBed") as AudioStreamPlayer
+	_expect(soundscape != null, "game scene must have a dedicated RestingSoundscape owner")
+	_expect(ocean_bed != null, "RestingSoundscape must expose an OceanBed AudioStreamPlayer")
+	if ocean_bed != null:
+		_expect(ocean_bed.stream != null, "OceanBed must have a technical prototype stream wired")
+		_expect(ocean_bed.autoplay, "OceanBed must autoplay so doing nothing still produces the resting space")
+		_expect(ocean_bed.volume_db <= -8.0, "technical OceanBed must start conservatively below -8 dB")
+
+	var pet := scene.get_node_or_null("VoyageWorld/RestingPetPlaceholder") as Node3D
+	_expect(pet != null, "game scene must include one clearly-placeholder resting pet")
+	if pet != null:
+		_expect(pet.has_method("get_resting_state"), "resting pet controller must expose its current low-pressure idle state")
+		_expect(pet.has_method("get_next_idle_seconds"), "resting pet controller must expose the next idle interval for testability")
+		if pet.has_method("get_next_idle_seconds"):
+			_expect(float(pet.call("get_next_idle_seconds")) >= 10.0, "pet idle interval must be long enough to avoid attention-seeking behavior")
+
+	var ocean := scene.get_node_or_null("VoyageWorld/OceanPlane") as MeshInstance3D
+	_expect(ocean != null, "resting prototype must keep an explicit OceanPlane")
+	if ocean != null:
+		var material := ocean.get_active_material(0) as StandardMaterial3D
+		_expect(material != null, "OceanPlane must have a readable soft-sea material")
+		if material != null:
+			_expect(material.roughness >= 0.85, "placeholder ocean must favor soft reflection over sharp glare")
+			_expect(material.albedo_color.v <= 0.75, "placeholder ocean must avoid excessively bright high-glare color")
+
+	scene.queue_free()
+	await process_frame
+	_finish()
+
+
+func _expect(condition: bool, message: String) -> void:
+	if condition:
+		return
+	_failures += 1
+	printerr("FAIL: %s" % message)
+
+
+func _finish() -> void:
+	if _failures == 0:
+		print("PASS: resting core technical prototype contract")
+		quit(0)
+	else:
+		printerr("FAILED: %d resting core assertions" % _failures)
+		quit(1)


### PR DESCRIPTION
Closes #8

## Goal
Build the smallest executable Resting Core technical prototype while preserving the evidence boundary between technical wiring and actual Human rest quality.

## Implemented
- persistent `RestingSoundscape` AutoLoad across menu/voyage/album Scene changes
- one runtime-generated 4s looping `AudioStreamWAV` OceanBed at `-16 dB`
- explicit `TECHNICAL_PROTOTYPE=true` evidence class; no external natural-audio asset is claimed
- softened ocean material/light and runtime mood-sky brightness range
- one rounded `RestingPetPlaceholder` with 12–24s low-density idle intervals and subtle breathing
- pet `has_care_obligation() == false`
- dedicated `test_resting_core_contract.gd` added to Godot 4.7 CI
- README / MVP Scope / Roadmap / audio contract synchronized to distinguish technical prototype vs production asset/Human evidence

## TDD / adversarial evidence
- initial RED: 5 intended Resting Core assertions failed while existing voyage/fishing/album/mobile contracts remained PASS
- GREEN established after minimal soundscape/pet/sea implementation
- adversarial loop 1: added TECHNICAL_PROTOTYPE / loop / no-care evidence guards
- loop 2: found scene-local sound restart risk; RED → moved soundscape to persistent AutoLoad → GREEN
- loop 3: separated technical audio wiring from production/Human claims in docs
- loop 4: found runtime mood sky overriding softer scene tone; RED brightness ceiling → corrected mood palette → GREEN
- loop 5: removed README/Roadmap/MVP runtime-document drift

## Exact verification
- exact reviewed HEAD: `a8b4af838c33e11546248f437990a0f1ad61d1df`
- Godot 4.7 validation run `32695279702` / run #63: SUCCESS
- no PR comments, reviews, or unresolved review threads
- base `main` remained `dc5500feb149ee15cdae1cbfbe486003a6ebdc8b` during final gate

## Evidence ceiling
- technical soundscape wiring: PASS
- production natural ocean recording: NOT_INTEGRATED
- Human audio listening: NOT_RUN
- final pet design/animation: NOT_INTEGRATED
- Human visual comfort: NOT_RUN
- real mobile rest test: NOT_RUN

No final sea/pet image was generated in this PR.