### PR TITLE
Design Bondee diorama and delayed bottle social

### DIFF
--- a/docs/superpowers/plans/2026-08-24-canon-migration-diorama-shell.md
+++ b/docs/superpowers/plans/2026-08-24-canon-migration-diorama-shell.md
@@ -426,3 +426,5 @@ Boat decoration runtime = NOT_IMPLEMENTED
 Bottle social runtime/backend = NOT_IMPLEMENTED
 Real mobile device QA = NOT_RUN
 ```
+
+Status: **PLAN COMPLETE / READY FOR INLINE EXECUTION AFTER DESIGN PR MERGE**

--- a/docs/superpowers/plans/2026-08-24-canon-migration-diorama-shell.md
+++ b/docs/superpowers/plans/2026-08-24-canon-migration-diorama-shell.md
@@ -22,6 +22,8 @@
 - No decoration editor, Interactable runtime, fake social backend, Supabase, FriendBottle, or DriftBottle runtime in this slice.
 - Future online social is limited to the approved delayed bottle subsystem and its identity/safety operations; no realtime/global/public chat.
 - `DriftBottle` future public enablement remains gated by moderation, Terms, age gate, report, block, and operations evidence.
+- Friend invite semantics are defined by the spec as one-time 8-character/24h code → invitee redemption → inviter confirmation; Slice 1 does not implement them.
+- Accepted bottle delivery timing uses `deliver_at <= server_now` polling semantics; Slice 1 does not implement server delivery.
 - No combat, HP, failure conditions, ranking, ads, payments, gacha pressure, or progression pressure.
 
 ---

--- a/docs/superpowers/plans/2026-08-24-canon-migration-diorama-shell.md
+++ b/docs/superpowers/plans/2026-08-24-canon-migration-diorama-shell.md
@@ -1,0 +1,405 @@
+# Canon Migration + Diorama Shell Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the repository from first-person-only/invisible-player canon to the approved Bondee-inspired visible-avatar 3/4 boat diorama shell while preserving the existing sea-focused Appreciation Camera and all current voyage/rest/fishing behavior.
+
+**Architecture:** Keep the current game scene and Resting Core systems, but make a fixed 3/4 `DioramaCameraRig` the normal active camera and convert the existing draggable first-person rig into the optional `AppreciationCameraRig`. Add one clearly technical visible avatar placeholder with a small customization-slot contract. `GameScene` owns camera-mode switching from the existing `GameState.appreciation_mode`; no decoration system or online backend is introduced in this slice.
+
+**Tech Stack:** Godot 4.7 stable, GDScript, `.tscn`, existing SceneTree contract tests, GitHub Actions Godot validation.
+
+**Spec:** `docs/superpowers/specs/2026-08-24-bondee-diorama-delayed-bottle-design.md`
+
+## Global Constraints
+
+- Godot 4.7 stable / GDScript.
+- Mobile portrait remains the primary screen constraint.
+- Normal play shows the player avatar and pet in a 3/4 boat diorama.
+- Appreciation Camera preserves the current sea-focused draggable view and low-UI rest behavior.
+- Appreciation Camera must not stop the voyage timer, soundscape, or alter rewards.
+- Existing fishing, Ambient Discovery, album, voyage-record, RestingSoundscape, and pet-resting contracts must remain green.
+- Avatar art in this slice is a clearly labeled technical placeholder, not production art.
+- No decoration editor, social fake backend, Supabase integration, FriendBottle, or DriftBottle runtime code in this slice.
+- Online social design is approved, but `DriftBottle` remains future-gated by moderation/safety implementation.
+- Do not add combat, HP, failure conditions, ranking, ads, payments, or progression pressure.
+
+---
+
+## File Structure for This Slice
+
+**Create**
+- `scripts/avatar/player_avatar_placeholder.gd` — technical visible-avatar identity/customization-slot contract only.
+- `tests/test_diorama_avatar_camera_contract.gd` — RED/GREEN contract for visible avatar, normal 3/4 camera, Appreciation Camera switching, and no reward/timer mutation.
+
+**Modify**
+- `AGENTS.md` — replace obsolete first-person/invisible-player/online-letter prohibition with the approved current operating canon and narrow online boundary.
+- `scenes/game.tscn` — add `DioramaCameraRig`, visible avatar placeholder mesh, and rename/reframe the old camera as `AppreciationCameraRig`.
+- `scripts/voyage/game_scene.gd` — own camera selection and drift bases for both rigs while preserving current gameplay.
+- `scripts/voyage/boat_camera_controller.gd` — update role/header language from first-person core camera to Appreciation Camera input controller; behavior stays the same.
+- `tests/test_game_scene_contract.gd` — update the drift-camera path after the explicit camera split and retain all previous assertions.
+- `tests/test_camera_input_contract.gd` — reframe assertions as Appreciation Camera input semantics without weakening clamp/horizon behavior.
+- `.github/workflows/godot-validation.yml` — run the new diorama/avatar contract.
+- `README.md` — describe implemented technical diorama shell and evidence ceiling.
+- `docs/CONCEPT.md` — mirror approved visible-avatar/boat-diorama product direction.
+- `docs/MVP_SCOPE.md` — distinguish implemented Slice 1 from future decoration/social work.
+- `docs/GODOT_MVP_ROADMAP.md` — mark Canon Migration + Diorama Shell state and next Slice 2.
+
+---
+
+### Task 1: Migrate the repository operating canon
+
+**Files:**
+- Modify: `AGENTS.md`
+
+**Interfaces:**
+- Consumes: approved design spec section 0–3 and section 20.
+- Produces: authoritative repository instructions that permit visible avatar + 3/4 diorama and permit only the narrowly designed delayed bottle social subsystem in later slices.
+
+- [ ] **Step 1: Replace obsolete project identity text**
+
+Change:
+
+```text
+Genre: first-person healing drifting boat game
+The player sits in a small boat and watches the sea. The player body is not visible.
+Do not add ... online letter sharing.
+```
+
+To an explicit current canon equivalent:
+
+```text
+Genre: rest-first cozy boat diorama / healing voyage game
+Normal play uses a visible player avatar + pet + decorated boat in a 3/4 diorama camera.
+Appreciation Camera preserves the sea-focused low-UI view.
+Online scope is allowed only for the approved delayed FriendBottle / DriftBottle subsystem and its required identity/safety operations; the rest of the game remains local-first.
+```
+
+- [ ] **Step 2: Update Core Game Direction**
+
+Add the new normal-play presentation and future supporting systems while preserving the 5-minute rest loop, photo, appreciation, speed, fishing, album, pet, and soundscape.
+
+- [ ] **Step 3: Add online safety boundary**
+
+State that future bottle-social runtime must follow the approved spec and cannot become realtime/global/public chat. `DriftBottle` public enablement requires moderation/report/block/Terms/age-gate evidence.
+
+- [ ] **Step 4: Read back `AGENTS.md`**
+
+Verify there is no remaining unconditional statement that the player body must be invisible or that all online letter sharing is forbidden.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add AGENTS.md
+git commit -m "Migrate project canon to boat diorama direction"
+```
+
+---
+
+### Task 2: RED — define the visible-avatar and camera-mode contract
+
+**Files:**
+- Create: `tests/test_diorama_avatar_camera_contract.gd`
+- Modify: `.github/workflows/godot-validation.yml`
+
+**Interfaces:**
+- Consumes: existing `GameState.appreciation_mode`, `scenes/game.tscn`.
+- Produces: behavioral contract for `PlayerAvatarPlaceholder`, `DioramaCameraRig/DioramaCamera3D`, `AppreciationCameraRig/AppreciationCamera3D`, and `GameScene.get_active_camera_mode()`.
+
+- [ ] **Step 1: Write failing contract**
+
+Create a SceneTree test with these assertions:
+
+```gdscript
+var avatar := scene.get_node_or_null("VoyageWorld/PlayerAvatarPlaceholder") as Node3D
+_expect(avatar != null, "normal play must include a visible player avatar placeholder")
+_expect(avatar.has_method("is_technical_placeholder"), "avatar must expose its evidence class")
+_expect(bool(avatar.call("is_technical_placeholder")), "current avatar must stay explicitly technical-placeholder evidence")
+
+var diorama_camera := scene.get_node_or_null("VoyageWorld/DioramaCameraRig/DioramaCamera3D") as Camera3D
+var appreciation_camera := scene.get_node_or_null("VoyageWorld/AppreciationCameraRig/AppreciationCamera3D") as Camera3D
+_expect(diorama_camera != null, "normal play must provide a DioramaCamera3D")
+_expect(appreciation_camera != null, "appreciation mode must preserve the sea-focused camera")
+_expect(diorama_camera.current, "diorama camera must be active in normal play")
+_expect(not appreciation_camera.current, "appreciation camera must be inactive in normal play")
+_expect(scene.has_method("get_active_camera_mode"), "game scene must expose active camera mode for contract tests")
+_expect(str(scene.call("get_active_camera_mode")) == "diorama", "normal play camera mode must be diorama")
+```
+
+Then press `%AppreciationButton`, await one frame, and assert:
+
+```gdscript
+_expect(not diorama_camera.current, "diorama camera must yield during appreciation mode")
+_expect(appreciation_camera.current, "appreciation camera must become active")
+_expect(str(scene.call("get_active_camera_mode")) == "appreciation", "camera mode must report appreciation")
+```
+
+Also snapshot `GameState.remaining_seconds`, `speed_index`, photo/letter/scenery/fish counts before toggling and assert the toggle itself changes none of them.
+
+- [ ] **Step 2: Add the new test to CI**
+
+Add:
+
+```bash
+godot --headless --path . --script res://tests/test_diorama_avatar_camera_contract.gd || status=1
+```
+
+to the focused behavior contracts.
+
+- [ ] **Step 3: Open/update the implementation PR and run CI**
+
+Expected RED failures must be specifically about missing avatar/diorama/appreciation camera split or missing camera-mode method. Existing contracts should remain PASS.
+
+- [ ] **Step 4: Inspect RED logs**
+
+Do not implement until the failing test demonstrates the missing feature rather than a syntax/path mistake.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_diorama_avatar_camera_contract.gd .github/workflows/godot-validation.yml
+git commit -m "Test visible avatar and diorama camera contract"
+```
+
+---
+
+### Task 3: GREEN — add the technical avatar shell and normal 3/4 diorama camera
+
+**Files:**
+- Create: `scripts/avatar/player_avatar_placeholder.gd`
+- Modify: `scenes/game.tscn`
+- Modify: `scripts/voyage/game_scene.gd`
+
+**Interfaces:**
+- Produces:
+  - `PlayerAvatarPlaceholder.is_technical_placeholder() -> bool`
+  - `PlayerAvatarPlaceholder.get_customization_slots() -> Array[String]`
+  - `GameScene.get_active_camera_mode() -> String`
+  - `GameScene._apply_camera_mode() -> void`
+
+- [ ] **Step 1: Implement minimal avatar placeholder script**
+
+```gdscript
+# 보이는 플레이어 캐릭터의 기술용 외형·커스터마이즈 슬롯 계약을 제공한다.
+extends Node3D
+
+const TECHNICAL_PLACEHOLDER := true
+const CUSTOMIZATION_SLOTS: Array[String] = [
+    "body",
+    "hair",
+    "top",
+    "bottom",
+    "head_accessory",
+    "accessory",
+    "color",
+]
+
+func is_technical_placeholder() -> bool:
+    return TECHNICAL_PLACEHOLDER
+
+func get_customization_slots() -> Array[String]:
+    return CUSTOMIZATION_SLOTS.duplicate()
+```
+
+No movement, inventory, stats, network identity, or final avatar art in this slice.
+
+- [ ] **Step 2: Add placeholder mesh to `game.tscn`**
+
+Create `VoyageWorld/PlayerAvatarPlaceholder` with rounded primitive body/head meshes and a matte material. Keep it clearly separate from `RestingPetPlaceholder` and positioned so both are readable in portrait diorama framing.
+
+- [ ] **Step 3: Split cameras in `game.tscn`**
+
+Create:
+
+```text
+VoyageWorld/DioramaCameraRig/DioramaCamera3D   current=true
+VoyageWorld/AppreciationCameraRig/AppreciationCamera3D current=false
+```
+
+Move the existing draggable camera controller to `AppreciationCameraRig`. Give the new Diorama camera a fixed 3/4 elevated transform that sees avatar + pet + boat + horizon.
+
+- [ ] **Step 4: Add camera-mode switching in `game_scene.gd`**
+
+Implement:
+
+```gdscript
+func get_active_camera_mode() -> String:
+    return "appreciation" if GameState.appreciation_mode else "diorama"
+
+func _apply_camera_mode() -> void:
+    $VoyageWorld/DioramaCameraRig/DioramaCamera3D.current = not GameState.appreciation_mode
+    $VoyageWorld/AppreciationCameraRig/AppreciationCamera3D.current = GameState.appreciation_mode
+```
+
+Call `_apply_camera_mode()` inside `_apply_appreciation_mode()` so UI and camera always transition from the same state.
+
+- [ ] **Step 5: Preserve speed/drift feedback in both modes**
+
+Store base positions for both camera rigs and apply only small vertical drift to each so speed control remains observable in the currently active camera. Do not change voyage duration or rewards.
+
+- [ ] **Step 6: Run exact-head CI**
+
+Expected: new diorama/avatar contract GREEN; existing contracts may reveal path assumptions that now need Task 4 migration.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scenes/game.tscn scripts/avatar/player_avatar_placeholder.gd scripts/voyage/game_scene.gd
+git commit -m "Add visible avatar and diorama camera shell"
+```
+
+---
+
+### Task 4: REFACTOR — migrate old camera-path contracts without weakening them
+
+**Files:**
+- Modify: `scripts/voyage/boat_camera_controller.gd`
+- Modify: `tests/test_game_scene_contract.gd`
+- Modify: `tests/test_camera_input_contract.gd`
+
+**Interfaces:**
+- Preserves existing input behavior: mouse drag + `InputEventScreenDrag`, pitch clamp `[-28, 18]`, roll `0`.
+- Reframes that behavior as Appreciation Camera input rather than normal first-person presentation.
+
+- [ ] **Step 1: Update controller role comment only**
+
+Change the source header to describe sea-focused Appreciation Camera drag input. Do not change sensitivity/clamp behavior unless a failing test requires it.
+
+- [ ] **Step 2: Update game-scene drift assertion path**
+
+Replace old `VoyageWorld/CameraRig` lookup with `VoyageWorld/DioramaCameraRig`, because normal-play speed feedback must be observable on the active diorama camera.
+
+- [ ] **Step 3: Reword camera input contract**
+
+Keep the same input simulation and numeric assertions, but describe it as Appreciation Camera behavior.
+
+- [ ] **Step 4: Run full CI**
+
+Expected: all behavior contracts + three scene smokes PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/voyage/boat_camera_controller.gd tests/test_game_scene_contract.gd tests/test_camera_input_contract.gd
+git commit -m "Preserve appreciation camera input contracts"
+```
+
+---
+
+### Task 5: Synchronize repository human-readable mirrors with implemented Slice 1
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/CONCEPT.md`
+- Modify: `docs/MVP_SCOPE.md`
+- Modify: `docs/GODOT_MVP_ROADMAP.md`
+
+**Interfaces:**
+- Consumes: implemented runtime truth from Tasks 1–4.
+- Produces: repository mirrors that do not falsely claim decor/social runtime exists yet.
+
+- [ ] **Step 1: README**
+
+State:
+
+```text
+TECH_DIORAMA_SHELL = implemented
+VISIBLE_AVATAR_PLACEHOLDER = implemented
+APPRECIATION_CAMERA = preserved
+BOAT_DECORATION = NOT_IMPLEMENTED
+FRIEND_BOTTLE = NOT_IMPLEMENTED
+DRIFT_BOTTLE = NOT_IMPLEMENTED
+```
+
+Do not call placeholder visual quality PASS.
+
+- [ ] **Step 2: Concept/MVP Scope**
+
+Replace first-person-only language with 3/4 visible-avatar normal play + optional Appreciation Camera. Keep online bottle systems as approved future scope, not runtime evidence.
+
+- [ ] **Step 3: Roadmap**
+
+Add/mark:
+
+```text
+Canon Migration + Diorama Shell — implemented / Human visual QA NOT_RUN
+Next: Local Decoration + Interactable
+```
+
+- [ ] **Step 4: Static readback**
+
+Search the touched mirrors for stale unconditional phrases such as `player body is not visible`, `first-person only`, or `online letter sharing forbidden` and remove only those now-invalid statements.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md docs/CONCEPT.md docs/MVP_SCOPE.md docs/GODOT_MVP_ROADMAP.md
+git commit -m "Sync diorama shell implementation mirrors"
+```
+
+---
+
+### Task 6: Final verification, adversarial review, merge, and Notion evidence sync
+
+**Files:**
+- No new runtime files unless review reveals a concrete defect.
+- Update Notion after merge.
+
+**Interfaces:**
+- Consumes: exact PR head and CI evidence.
+- Produces: merged main SHA + Notion `SYNCED` evidence for implemented Slice 1 while future systems remain `REPO_UPDATE_REQUIRED`.
+
+- [ ] **Step 1: Exact-head verification**
+
+Verify the PR head SHA and ensure the latest Godot 4.7 workflow run on that exact head is SUCCESS.
+
+- [ ] **Step 2: Whole-state adversarial review loop 1–5**
+
+Attack at minimum:
+
+1. old first-person/no-online canon still silently controlling implementation;
+2. Appreciation Camera losing existing touch/mouse behavior or affecting rewards/timer;
+3. visible avatar blocking sea/pet or becoming final-art evidence by accident;
+4. 3/4 camera making speed bob/motion sickness worse or UI unreadable in portrait;
+5. docs/Notion claiming decoration/social backend exists when only the shell exists.
+
+Any new valid finding resets the clean-loop count after correction according to project workflow.
+
+- [ ] **Step 3: PR review surfaces**
+
+Check changed files, full patch, comments, reviews, unresolved threads, and base-main movement.
+
+- [ ] **Step 4: Merge with expected head SHA**
+
+Use squash merge only after exact-head CI and review are clean.
+
+- [ ] **Step 5: Postmerge readback**
+
+Verify new `main` SHA and merged files. Confirm the current-task issue closes if linked.
+
+- [ ] **Step 6: Notion sync**
+
+Update:
+
+- Project Registry `Repo Main SHA`, revision, notes;
+- Home current state;
+- `3/4 디오라마 플레이어·카메라` record → `SYNCED` with merged SHA;
+- existing core loop source/evidence as appropriate;
+- Production Handoff receipt.
+
+Leave `보트 꾸미기 슬롯 존`, `저압력 상호작용 시스템`, `FriendBottle`, `DriftBottle`, and social-safety runtime records as future/not-implemented (`REPO_UPDATE_REQUIRED`) unless actually implemented in a later slice.
+
+- [ ] **Step 7: Final evidence ceiling**
+
+Report separately:
+
+```text
+Godot contract/scene behavior = PASS if CI proves it
+Visible avatar technical shell = PASS
+3/4 camera technical shell = PASS
+Appreciation Camera preservation = PASS
+Human visual comfort = NOT_RUN
+Final avatar art = NOT_INTEGRATED
+Boat decoration runtime = NOT_IMPLEMENTED
+Bottle social runtime/backend = NOT_IMPLEMENTED
+Real mobile device QA = NOT_RUN
+```

--- a/docs/superpowers/plans/2026-08-24-canon-migration-diorama-shell.md
+++ b/docs/superpowers/plans/2026-08-24-canon-migration-diorama-shell.md
@@ -4,87 +4,78 @@
 
 **Goal:** Migrate the repository from first-person-only/invisible-player canon to the approved Bondee-inspired visible-avatar 3/4 boat diorama shell while preserving the existing sea-focused Appreciation Camera and all current voyage/rest/fishing behavior.
 
-**Architecture:** Keep the current game scene and Resting Core systems, but make a fixed 3/4 `DioramaCameraRig` the normal active camera and convert the existing draggable first-person rig into the optional `AppreciationCameraRig`. Add one clearly technical visible avatar placeholder with a small customization-slot contract. `GameScene` owns camera-mode switching from the existing `GameState.appreciation_mode`; no decoration system or online backend is introduced in this slice.
+**Architecture:** Keep the existing voyage scene and Resting Core systems. Add a fixed 3/4 `DioramaCameraRig` as the normal camera, convert the existing draggable rig into `AppreciationCameraRig`, and add one clearly technical visible avatar placeholder. `GameScene` switches cameras from `GameState.appreciation_mode`. The Appreciation Camera controller processes drag input only while its camera is current so it cannot steal normal diorama touch input.
 
-**Tech Stack:** Godot 4.7 stable, GDScript, `.tscn`, existing SceneTree contract tests, GitHub Actions Godot validation.
+**Tech Stack:** Godot 4.7 stable, GDScript, `.tscn`, SceneTree contract tests, GitHub Actions Godot validation.
 
 **Spec:** `docs/superpowers/specs/2026-08-24-bondee-diorama-delayed-bottle-design.md`
 
 ## Global Constraints
 
 - Godot 4.7 stable / GDScript.
-- Mobile portrait remains the primary screen constraint.
-- Normal play shows the player avatar and pet in a 3/4 boat diorama.
-- Appreciation Camera preserves the current sea-focused draggable view and low-UI rest behavior.
-- Appreciation Camera must not stop the voyage timer, soundscape, or alter rewards.
-- Existing fishing, Ambient Discovery, album, voyage-record, RestingSoundscape, and pet-resting contracts must remain green.
-- Avatar art in this slice is a clearly labeled technical placeholder, not production art.
-- No decoration editor, social fake backend, Supabase integration, FriendBottle, or DriftBottle runtime code in this slice.
-- Online social design is approved, but `DriftBottle` remains future-gated by moderation/safety implementation.
-- Do not add combat, HP, failure conditions, ranking, ads, payments, or progression pressure.
+- Mobile portrait remains primary.
+- Normal play shows avatar + pet + boat + sea in a 3/4 diorama.
+- Appreciation Camera preserves the existing sea-focused draggable view and low-UI rest behavior.
+- Camera switching does not stop voyage time, soundscape, or alter rewards.
+- Existing fishing, Ambient Discovery, album, voyage-record, RestingSoundscape, and pet-resting contracts remain green.
+- Avatar in this slice is `TECHNICAL_PLACEHOLDER`, not production art.
+- No decoration editor, Interactable runtime, fake social backend, Supabase, FriendBottle, or DriftBottle runtime in this slice.
+- Future online social is limited to the approved delayed bottle subsystem and its identity/safety operations; no realtime/global/public chat.
+- `DriftBottle` future public enablement remains gated by moderation, Terms, age gate, report, block, and operations evidence.
+- No combat, HP, failure conditions, ranking, ads, payments, gacha pressure, or progression pressure.
 
 ---
 
-## File Structure for This Slice
+## File Map
 
 **Create**
-- `scripts/avatar/player_avatar_placeholder.gd` — technical visible-avatar identity/customization-slot contract only.
-- `tests/test_diorama_avatar_camera_contract.gd` — RED/GREEN contract for visible avatar, normal 3/4 camera, Appreciation Camera switching, and no reward/timer mutation.
+- `scripts/avatar/player_avatar_placeholder.gd` — technical visible-avatar/customization-slot contract.
+- `tests/test_diorama_avatar_camera_contract.gd` — avatar + normal/appreciation camera-mode behavior.
 
 **Modify**
-- `AGENTS.md` — replace obsolete first-person/invisible-player/online-letter prohibition with the approved current operating canon and narrow online boundary.
-- `scenes/game.tscn` — add `DioramaCameraRig`, visible avatar placeholder mesh, and rename/reframe the old camera as `AppreciationCameraRig`.
-- `scripts/voyage/game_scene.gd` — own camera selection and drift bases for both rigs while preserving current gameplay.
-- `scripts/voyage/boat_camera_controller.gd` — update role/header language from first-person core camera to Appreciation Camera input controller; behavior stays the same.
-- `tests/test_game_scene_contract.gd` — update the drift-camera path after the explicit camera split and retain all previous assertions.
-- `tests/test_camera_input_contract.gd` — reframe assertions as Appreciation Camera input semantics without weakening clamp/horizon behavior.
-- `.github/workflows/godot-validation.yml` — run the new diorama/avatar contract.
-- `README.md` — describe implemented technical diorama shell and evidence ceiling.
-- `docs/CONCEPT.md` — mirror approved visible-avatar/boat-diorama product direction.
-- `docs/MVP_SCOPE.md` — distinguish implemented Slice 1 from future decoration/social work.
-- `docs/GODOT_MVP_ROADMAP.md` — mark Canon Migration + Diorama Shell state and next Slice 2.
+- `AGENTS.md`
+- `scenes/game.tscn`
+- `scripts/voyage/game_scene.gd`
+- `scripts/voyage/boat_camera_controller.gd`
+- `tests/test_game_scene_contract.gd`
+- `tests/test_camera_input_contract.gd`
+- `.github/workflows/godot-validation.yml`
+- `README.md`
+- `docs/CONCEPT.md`
+- `docs/MVP_SCOPE.md`
+- `docs/GODOT_MVP_ROADMAP.md`
 
 ---
 
-### Task 1: Migrate the repository operating canon
+### Task 1: Migrate repository operating canon
 
 **Files:**
 - Modify: `AGENTS.md`
 
-**Interfaces:**
-- Consumes: approved design spec section 0–3 and section 20.
-- Produces: authoritative repository instructions that permit visible avatar + 3/4 diorama and permit only the narrowly designed delayed bottle social subsystem in later slices.
+**Produces:** repository authority that explicitly permits visible-avatar 3/4 diorama normal play and only the approved delayed-bottle online boundary.
 
-- [ ] **Step 1: Replace obsolete project identity text**
+- [ ] **Step 1: Replace obsolete identity lines**
 
-Change:
-
-```text
-Genre: first-person healing drifting boat game
-The player sits in a small boat and watches the sea. The player body is not visible.
-Do not add ... online letter sharing.
-```
-
-To an explicit current canon equivalent:
+Replace the old first-person-only, invisible-player, and blanket online-letter prohibition with:
 
 ```text
 Genre: rest-first cozy boat diorama / healing voyage game
-Normal play uses a visible player avatar + pet + decorated boat in a 3/4 diorama camera.
+Normal play uses a visible player avatar + pet + boat in a 3/4 diorama camera.
 Appreciation Camera preserves the sea-focused low-UI view.
-Online scope is allowed only for the approved delayed FriendBottle / DriftBottle subsystem and its required identity/safety operations; the rest of the game remains local-first.
+Online scope is allowed only for the approved delayed FriendBottle / DriftBottle subsystem and required identity/safety operations; core rest/voyage/decor/pet systems remain local-first.
 ```
 
 - [ ] **Step 2: Update Core Game Direction**
 
-Add the new normal-play presentation and future supporting systems while preserving the 5-minute rest loop, photo, appreciation, speed, fishing, album, pet, and soundscape.
+Preserve the 5-minute rest loop, photo, appreciation, speed, fishing, album, pet, and soundscape. Add visible avatar, future boat decoration, low-pressure interaction, and delayed bottle social as approved supporting directions.
 
-- [ ] **Step 3: Add online safety boundary**
+- [ ] **Step 3: Add social safety boundary**
 
-State that future bottle-social runtime must follow the approved spec and cannot become realtime/global/public chat. `DriftBottle` public enablement requires moderation/report/block/Terms/age-gate evidence.
+State that bottle social cannot become realtime/global/public chat and that future `DriftBottle` release requires moderation/report/block/Terms/age-gate evidence.
 
-- [ ] **Step 4: Read back `AGENTS.md`**
+- [ ] **Step 4: Static readback**
 
-Verify there is no remaining unconditional statement that the player body must be invisible or that all online letter sharing is forbidden.
+Verify no unconditional `player body is not visible`, `first-person only`, or blanket `online letter sharing` prohibition remains.
 
 - [ ] **Step 5: Commit**
 
@@ -95,47 +86,56 @@ git commit -m "Migrate project canon to boat diorama direction"
 
 ---
 
-### Task 2: RED — define the visible-avatar and camera-mode contract
+### Task 2: RED — visible avatar and camera-mode contract
 
 **Files:**
 - Create: `tests/test_diorama_avatar_camera_contract.gd`
 - Modify: `.github/workflows/godot-validation.yml`
 
-**Interfaces:**
-- Consumes: existing `GameState.appreciation_mode`, `scenes/game.tscn`.
-- Produces: behavioral contract for `PlayerAvatarPlaceholder`, `DioramaCameraRig/DioramaCamera3D`, `AppreciationCameraRig/AppreciationCamera3D`, and `GameScene.get_active_camera_mode()`.
+**Produces:** contract for `PlayerAvatarPlaceholder`, `DioramaCameraRig/DioramaCamera3D`, `AppreciationCameraRig/AppreciationCamera3D`, and `GameScene.get_active_camera_mode()`.
 
-- [ ] **Step 1: Write failing contract**
+- [ ] **Step 1: Write failing SceneTree test**
 
-Create a SceneTree test with these assertions:
+Before scene instantiation, normalize state:
+
+```gdscript
+var game_state := root.get_node_or_null("GameState")
+_expect(game_state != null, "GameState autoload must exist")
+game_state.reset_session()
+game_state.voyage_active = true
+game_state.remaining_seconds = 123.0
+game_state.appreciation_mode = false
+```
+
+After instantiation assert:
 
 ```gdscript
 var avatar := scene.get_node_or_null("VoyageWorld/PlayerAvatarPlaceholder") as Node3D
 _expect(avatar != null, "normal play must include a visible player avatar placeholder")
 _expect(avatar.has_method("is_technical_placeholder"), "avatar must expose its evidence class")
-_expect(bool(avatar.call("is_technical_placeholder")), "current avatar must stay explicitly technical-placeholder evidence")
+_expect(bool(avatar.call("is_technical_placeholder")), "avatar must remain technical-placeholder evidence")
 
 var diorama_camera := scene.get_node_or_null("VoyageWorld/DioramaCameraRig/DioramaCamera3D") as Camera3D
 var appreciation_camera := scene.get_node_or_null("VoyageWorld/AppreciationCameraRig/AppreciationCamera3D") as Camera3D
-_expect(diorama_camera != null, "normal play must provide a DioramaCamera3D")
-_expect(appreciation_camera != null, "appreciation mode must preserve the sea-focused camera")
-_expect(diorama_camera.current, "diorama camera must be active in normal play")
+_expect(diorama_camera != null, "normal play must provide DioramaCamera3D")
+_expect(appreciation_camera != null, "appreciation mode must preserve a sea-focused camera")
+_expect(diorama_camera.current, "diorama camera must be current in normal play")
 _expect(not appreciation_camera.current, "appreciation camera must be inactive in normal play")
-_expect(scene.has_method("get_active_camera_mode"), "game scene must expose active camera mode for contract tests")
-_expect(str(scene.call("get_active_camera_mode")) == "diorama", "normal play camera mode must be diorama")
+_expect(scene.has_method("get_active_camera_mode"), "game scene must expose camera mode")
+_expect(str(scene.call("get_active_camera_mode")) == "diorama", "normal camera mode must be diorama")
 ```
 
-Then press `%AppreciationButton`, await one frame, and assert:
+Snapshot `remaining_seconds`, `speed_index`, and photo/scenery/letter/fish counts. Press `%AppreciationButton`, await one frame, then assert:
 
 ```gdscript
-_expect(not diorama_camera.current, "diorama camera must yield during appreciation mode")
-_expect(appreciation_camera.current, "appreciation camera must become active")
+_expect(not diorama_camera.current, "diorama camera must yield in appreciation mode")
+_expect(appreciation_camera.current, "appreciation camera must become current")
 _expect(str(scene.call("get_active_camera_mode")) == "appreciation", "camera mode must report appreciation")
 ```
 
-Also snapshot `GameState.remaining_seconds`, `speed_index`, photo/letter/scenery/fish counts before toggling and assert the toggle itself changes none of them.
+Assert the toggle itself changed none of the snapshotted progression values.
 
-- [ ] **Step 2: Add the new test to CI**
+- [ ] **Step 2: Add test to CI**
 
 Add:
 
@@ -143,15 +143,13 @@ Add:
 godot --headless --path . --script res://tests/test_diorama_avatar_camera_contract.gd || status=1
 ```
 
-to the focused behavior contracts.
+- [ ] **Step 3: Open implementation PR and observe RED**
 
-- [ ] **Step 3: Open/update the implementation PR and run CI**
-
-Expected RED failures must be specifically about missing avatar/diorama/appreciation camera split or missing camera-mode method. Existing contracts should remain PASS.
+Expected failures: missing avatar, missing camera split, missing camera-mode API. Existing contracts should remain PASS.
 
 - [ ] **Step 4: Inspect RED logs**
 
-Do not implement until the failing test demonstrates the missing feature rather than a syntax/path mistake.
+If failure is syntax/path setup rather than missing behavior, fix the test and rerun until RED is semantically correct.
 
 - [ ] **Step 5: Commit**
 
@@ -162,21 +160,20 @@ git commit -m "Test visible avatar and diorama camera contract"
 
 ---
 
-### Task 3: GREEN — add the technical avatar shell and normal 3/4 diorama camera
+### Task 3: GREEN — technical avatar shell and 3/4 diorama camera
 
 **Files:**
 - Create: `scripts/avatar/player_avatar_placeholder.gd`
 - Modify: `scenes/game.tscn`
 - Modify: `scripts/voyage/game_scene.gd`
 
-**Interfaces:**
-- Produces:
-  - `PlayerAvatarPlaceholder.is_technical_placeholder() -> bool`
-  - `PlayerAvatarPlaceholder.get_customization_slots() -> Array[String]`
-  - `GameScene.get_active_camera_mode() -> String`
-  - `GameScene._apply_camera_mode() -> void`
+**Produces:**
+- `PlayerAvatarPlaceholder.is_technical_placeholder() -> bool`
+- `PlayerAvatarPlaceholder.get_customization_slots() -> Array[String]`
+- `GameScene.get_active_camera_mode() -> String`
+- `GameScene._apply_camera_mode() -> void`
 
-- [ ] **Step 1: Implement minimal avatar placeholder script**
+- [ ] **Step 1: Implement avatar placeholder contract**
 
 ```gdscript
 # 보이는 플레이어 캐릭터의 기술용 외형·커스터마이즈 슬롯 계약을 제공한다.
@@ -200,26 +197,22 @@ func get_customization_slots() -> Array[String]:
     return CUSTOMIZATION_SLOTS.duplicate()
 ```
 
-No movement, inventory, stats, network identity, or final avatar art in this slice.
+- [ ] **Step 2: Add visible rounded avatar mesh**
 
-- [ ] **Step 2: Add placeholder mesh to `game.tscn`**
+Create `VoyageWorld/PlayerAvatarPlaceholder` with rounded primitive body/head meshes and matte material. Position it so avatar and `RestingPetPlaceholder` are both visible in portrait diorama composition. Do not imply final art quality.
 
-Create `VoyageWorld/PlayerAvatarPlaceholder` with rounded primitive body/head meshes and a matte material. Keep it clearly separate from `RestingPetPlaceholder` and positioned so both are readable in portrait diorama framing.
+- [ ] **Step 3: Split camera rigs**
 
-- [ ] **Step 3: Split cameras in `game.tscn`**
-
-Create:
+Scene structure:
 
 ```text
-VoyageWorld/DioramaCameraRig/DioramaCamera3D   current=true
-VoyageWorld/AppreciationCameraRig/AppreciationCamera3D current=false
+VoyageWorld/DioramaCameraRig/DioramaCamera3D             current=true
+VoyageWorld/AppreciationCameraRig/AppreciationCamera3D   current=false
 ```
 
-Move the existing draggable camera controller to `AppreciationCameraRig`. Give the new Diorama camera a fixed 3/4 elevated transform that sees avatar + pet + boat + horizon.
+Move the existing `boat_camera_controller.gd` onto `AppreciationCameraRig`. Set `DioramaCameraRig` to a fixed elevated 3/4 transform showing avatar + pet + boat + horizon.
 
-- [ ] **Step 4: Add camera-mode switching in `game_scene.gd`**
-
-Implement:
+- [ ] **Step 4: Implement camera selection**
 
 ```gdscript
 func get_active_camera_mode() -> String:
@@ -230,15 +223,15 @@ func _apply_camera_mode() -> void:
     $VoyageWorld/AppreciationCameraRig/AppreciationCamera3D.current = GameState.appreciation_mode
 ```
 
-Call `_apply_camera_mode()` inside `_apply_appreciation_mode()` so UI and camera always transition from the same state.
+Call `_apply_camera_mode()` from `_apply_appreciation_mode()`.
 
-- [ ] **Step 5: Preserve speed/drift feedback in both modes**
+- [ ] **Step 5: Preserve speed/drift feedback**
 
-Store base positions for both camera rigs and apply only small vertical drift to each so speed control remains observable in the currently active camera. Do not change voyage duration or rewards.
+Store base positions for both camera rigs and apply small vertical drift to both. Existing speed choices still change felt drift but never duration/reward.
 
 - [ ] **Step 6: Run exact-head CI**
 
-Expected: new diorama/avatar contract GREEN; existing contracts may reveal path assumptions that now need Task 4 migration.
+Expected: new avatar/camera contract GREEN. Fix only production behavior needed by the contract.
 
 - [ ] **Step 7: Commit**
 
@@ -249,43 +242,77 @@ git commit -m "Add visible avatar and diorama camera shell"
 
 ---
 
-### Task 4: REFACTOR — migrate old camera-path contracts without weakening them
+### Task 4: RED/GREEN — Appreciation Camera must not steal normal diorama input
 
 **Files:**
 - Modify: `scripts/voyage/boat_camera_controller.gd`
-- Modify: `tests/test_game_scene_contract.gd`
 - Modify: `tests/test_camera_input_contract.gd`
+- Modify: `tests/test_game_scene_contract.gd`
 
-**Interfaces:**
-- Preserves existing input behavior: mouse drag + `InputEventScreenDrag`, pitch clamp `[-28, 18]`, roll `0`.
-- Reframes that behavior as Appreciation Camera input rather than normal first-person presentation.
+**Produces:** `boat_camera_controller.gd` handles mouse/touch drag only when its child `AppreciationCamera3D.current == true`.
 
-- [ ] **Step 1: Update controller role comment only**
+- [ ] **Step 1: Extend camera input test with an inactive-camera RED case**
 
-Change the source header to describe sea-focused Appreciation Camera drag input. Do not change sensitivity/clamp behavior unless a failing test requires it.
+Construct the rig with a child camera named `AppreciationCamera3D`, set `current = false`, send `InputEventScreenDrag`, and assert rotation is unchanged:
 
-- [ ] **Step 2: Update game-scene drift assertion path**
+```gdscript
+camera.current = false
+var inactive_before := rig.rotation_degrees
+var inactive_drag := InputEventScreenDrag.new()
+inactive_drag.relative = Vector2(28.0, -14.0)
+rig.call("_unhandled_input", inactive_drag)
+_expect(rig.rotation_degrees == inactive_before, "inactive Appreciation Camera must not consume diorama drag behavior")
+```
 
-Replace old `VoyageWorld/CameraRig` lookup with `VoyageWorld/DioramaCameraRig`, because normal-play speed feedback must be observable on the active diorama camera.
+Then set `camera.current = true`, send the same drag, and preserve existing assertions for changed rotation, roll `0`, and pitch clamp `[-28, 18]`.
 
-- [ ] **Step 3: Reword camera input contract**
+- [ ] **Step 2: Run CI and verify RED**
 
-Keep the same input simulation and numeric assertions, but describe it as Appreciation Camera behavior.
+Expected RED: inactive Appreciation Camera still rotates because the old controller has no active-camera gate.
 
-- [ ] **Step 4: Run full CI**
+- [ ] **Step 3: Implement minimal active-camera gate**
 
-Expected: all behavior contracts + three scene smokes PASS.
+In `boat_camera_controller.gd` add:
 
-- [ ] **Step 5: Commit**
+```gdscript
+@onready var _controlled_camera := get_node_or_null("AppreciationCamera3D") as Camera3D
+
+func _is_input_active() -> bool:
+    return _controlled_camera != null and _controlled_camera.current
+```
+
+Start `_unhandled_input(event)` with:
+
+```gdscript
+if not _is_input_active():
+    _dragging = false
+    return
+```
+
+Keep existing sensitivity, pitch clamp, yaw, and zero-roll behavior unchanged.
+
+- [ ] **Step 4: Update role/header language**
+
+Describe the script as the sea-focused Appreciation Camera PC/touch drag controller, not the normal first-person camera.
+
+- [ ] **Step 5: Update game-scene contract path**
+
+Replace its normal-play drift lookup from old `VoyageWorld/CameraRig` to `VoyageWorld/DioramaCameraRig`. Retain all prior behavior assertions.
+
+- [ ] **Step 6: Run full CI**
+
+Expected: all existing contracts + new diorama/avatar contract PASS; all three scene smokes PASS.
+
+- [ ] **Step 7: Commit**
 
 ```bash
-git add scripts/voyage/boat_camera_controller.gd tests/test_game_scene_contract.gd tests/test_camera_input_contract.gd
-git commit -m "Preserve appreciation camera input contracts"
+git add scripts/voyage/boat_camera_controller.gd tests/test_camera_input_contract.gd tests/test_game_scene_contract.gd
+git commit -m "Gate appreciation camera drag input"
 ```
 
 ---
 
-### Task 5: Synchronize repository human-readable mirrors with implemented Slice 1
+### Task 5: Synchronize repository mirrors with implemented Slice 1
 
 **Files:**
 - Modify: `README.md`
@@ -293,41 +320,38 @@ git commit -m "Preserve appreciation camera input contracts"
 - Modify: `docs/MVP_SCOPE.md`
 - Modify: `docs/GODOT_MVP_ROADMAP.md`
 
-**Interfaces:**
-- Consumes: implemented runtime truth from Tasks 1–4.
-- Produces: repository mirrors that do not falsely claim decor/social runtime exists yet.
+**Produces:** repository mirrors that distinguish implemented technical shell from future decor/social systems.
 
-- [ ] **Step 1: README**
+- [ ] **Step 1: README evidence table/text**
 
-State:
+State exactly:
 
 ```text
 TECH_DIORAMA_SHELL = implemented
 VISIBLE_AVATAR_PLACEHOLDER = implemented
 APPRECIATION_CAMERA = preserved
 BOAT_DECORATION = NOT_IMPLEMENTED
+INTERACTABLE_RUNTIME = NOT_IMPLEMENTED
 FRIEND_BOTTLE = NOT_IMPLEMENTED
 DRIFT_BOTTLE = NOT_IMPLEMENTED
 ```
 
-Do not call placeholder visual quality PASS.
+- [ ] **Step 2: Concept and MVP Scope**
 
-- [ ] **Step 2: Concept/MVP Scope**
-
-Replace first-person-only language with 3/4 visible-avatar normal play + optional Appreciation Camera. Keep online bottle systems as approved future scope, not runtime evidence.
+Replace first-person-only language with visible-avatar 3/4 normal play + optional Appreciation Camera. Keep bottle social as approved future runtime scope.
 
 - [ ] **Step 3: Roadmap**
 
-Add/mark:
+Add:
 
 ```text
 Canon Migration + Diorama Shell — implemented / Human visual QA NOT_RUN
-Next: Local Decoration + Interactable
+Next — Local Decoration + Interactable
 ```
 
-- [ ] **Step 4: Static readback**
+- [ ] **Step 4: Static stale-language scan**
 
-Search the touched mirrors for stale unconditional phrases such as `player body is not visible`, `first-person only`, or `online letter sharing forbidden` and remove only those now-invalid statements.
+Read touched mirrors and remove only unconditional now-invalid phrases such as `player body is not visible`, `first-person only`, or blanket `online letter sharing forbidden`.
 
 - [ ] **Step 5: Commit**
 
@@ -338,65 +362,62 @@ git commit -m "Sync diorama shell implementation mirrors"
 
 ---
 
-### Task 6: Final verification, adversarial review, merge, and Notion evidence sync
+### Task 6: Exact verification, adversarial review, merge, and Notion sync
 
 **Files:**
-- No new runtime files unless review reveals a concrete defect.
+- Runtime/docs only if a concrete review defect is found.
 - Update Notion after merge.
-
-**Interfaces:**
-- Consumes: exact PR head and CI evidence.
-- Produces: merged main SHA + Notion `SYNCED` evidence for implemented Slice 1 while future systems remain `REPO_UPDATE_REQUIRED`.
 
 - [ ] **Step 1: Exact-head verification**
 
-Verify the PR head SHA and ensure the latest Godot 4.7 workflow run on that exact head is SUCCESS.
+Confirm PR head SHA and latest Godot 4.7 workflow on that exact head is `SUCCESS`.
 
-- [ ] **Step 2: Whole-state adversarial review loop 1–5**
+- [ ] **Step 2: Whole-state adversarial review, five clean loops**
 
 Attack at minimum:
 
-1. old first-person/no-online canon still silently controlling implementation;
-2. Appreciation Camera losing existing touch/mouse behavior or affecting rewards/timer;
-3. visible avatar blocking sea/pet or becoming final-art evidence by accident;
-4. 3/4 camera making speed bob/motion sickness worse or UI unreadable in portrait;
-5. docs/Notion claiming decoration/social backend exists when only the shell exists.
+1. stale first-person/no-online canon still governing future work;
+2. Appreciation Camera input handling stealing normal diorama touch input or changing timer/rewards;
+3. avatar placeholder being mistaken for final art or obscuring pet/sea;
+4. 3/4 camera/drift creating excessive motion or breaking portrait composition at the technical-contract level;
+5. README/Notion claiming decor/social backend runtime exists when only Slice 1 exists.
 
-Any new valid finding resets the clean-loop count after correction according to project workflow.
+A newly discovered valid defect is corrected and the clean-loop count restarts according to project workflow.
 
 - [ ] **Step 3: PR review surfaces**
 
-Check changed files, full patch, comments, reviews, unresolved threads, and base-main movement.
+Inspect changed filenames, full patch, comments, reviews, unresolved threads, and base-main movement.
 
 - [ ] **Step 4: Merge with expected head SHA**
 
-Use squash merge only after exact-head CI and review are clean.
+Squash only after exact-head verification and review are clean.
 
 - [ ] **Step 5: Postmerge readback**
 
-Verify new `main` SHA and merged files. Confirm the current-task issue closes if linked.
+Verify `main` SHA and merged files and ensure the current implementation issue closes if linked.
 
-- [ ] **Step 6: Notion sync**
+- [ ] **Step 6: Notion evidence sync**
 
 Update:
 
-- Project Registry `Repo Main SHA`, revision, notes;
+- Project Registry main SHA/revision/notes;
 - Home current state;
-- `3/4 디오라마 플레이어·카메라` record → `SYNCED` with merged SHA;
-- existing core loop source/evidence as appropriate;
+- `3/4 디오라마 플레이어·카메라` → `SYNCED` with merged SHA;
+- voyage core loop source/evidence where applicable;
 - Production Handoff receipt.
 
-Leave `보트 꾸미기 슬롯 존`, `저압력 상호작용 시스템`, `FriendBottle`, `DriftBottle`, and social-safety runtime records as future/not-implemented (`REPO_UPDATE_REQUIRED`) unless actually implemented in a later slice.
+Keep `보트 꾸미기 슬롯 존`, `저압력 상호작용 시스템`, `FriendBottle`, `DriftBottle`, and `병편지 소셜 안전·모더레이션` as future runtime work (`REPO_UPDATE_REQUIRED`) until their own slices are implemented.
 
 - [ ] **Step 7: Final evidence ceiling**
 
-Report separately:
+Report:
 
 ```text
-Godot contract/scene behavior = PASS if CI proves it
+Godot contract/scene behavior = PASS if exact-head CI proves it
 Visible avatar technical shell = PASS
 3/4 camera technical shell = PASS
 Appreciation Camera preservation = PASS
+Appreciation input isolation = PASS
 Human visual comfort = NOT_RUN
 Final avatar art = NOT_INTEGRATED
 Boat decoration runtime = NOT_IMPLEMENTED

--- a/docs/superpowers/specs/2026-08-24-bondee-diorama-delayed-bottle-design.md
+++ b/docs/superpowers/specs/2026-08-24-bondee-diorama-delayed-bottle-design.md
@@ -1,0 +1,791 @@
+# Rest-first Bondee Boat Diorama + Delayed Bottle Social Design
+
+Status: **USER-APPROVED DESIGN / IMPLEMENTATION GATED BY WRITTEN SPEC REVIEW**  
+Date: 2026-08-24  
+Issue: #12  
+Base repository main at design start: `b6949a0b92f591bc099a5cf143b9fe32a863e45f`
+
+## 0. Authority and migration note
+
+This design captures the user's latest approved product direction and therefore supersedes the older product assumptions that the game must be first-person-only, that the player body must never be visible, and that online bottle-letter sharing is forbidden.
+
+The current `AGENTS.md` still contains those older constraints. **Do not implement against the new design by silently ignoring `AGENTS.md`.** The first implementation slice must update the project operating canon explicitly, then move runtime work forward under the new authority.
+
+Notion remains the human-facing design canon. Repository Markdown is the structured implementation mirror. Runtime claims still require Godot/code/test evidence.
+
+---
+
+## 1. Product North Star
+
+### One sentence
+
+**A small storybook boat diorama where the player's visible avatar and pet quietly live, decorate, rest, and exchange slowly drifting bottle letters without turning the experience into a realtime social network.**
+
+### Emotional priority
+
+1. Rest and comfort.
+2. Personal attachment to avatar, pet, and boat.
+3. A sense that the boat is "my small place".
+4. Gentle object and pet interaction.
+5. Unexpected human warmth through bottle letters.
+6. Collection and customization as memory, not optimization.
+
+No new system may make efficiency, urgency, social status, streaks, FOMO, ranking, or response pressure more important than the above order.
+
+---
+
+## 2. Core experience shift
+
+### Before
+
+- Primary presentation: first-person sea appreciation.
+- Player body not visible.
+- Boat mainly functions as viewpoint/container.
+- Bottle letters are authored ambient content only.
+- Online social exchange prohibited.
+
+### After
+
+- Primary presentation: **3/4 diorama camera** showing the player's avatar, pet, boat, decorations, and sea together.
+- Optional **Appreciation Camera** preserves the existing close sea-view/first-person-like relaxation mode.
+- Boat becomes a personal living space with low-pressure decoration and interaction.
+- Bottle letters become two systems:
+  - `FriendBottle`: delayed direct correspondence with an accepted friend.
+  - `DriftBottle`: delayed, limited correspondence with an unknown user.
+- Online scope stays isolated to social identity + bottle delivery + safety operations. Voyage, pet, decoration, album, fishing, soundscape, and rest loop remain local-first.
+
+---
+
+## 3. Camera and avatar design
+
+### Primary camera: 3/4 Boat Diorama
+
+Requirements:
+
+- Show avatar + pet + useful portion of boat + horizon in one calm composition.
+- Keep camera movement slow, bounded, and predictable.
+- Mobile portrait remains the primary screen constraint.
+- Camera should not constantly follow tiny avatar movement with aggressive easing.
+- The player's decorations must remain readable without covering the sea.
+
+### Appreciation Camera
+
+The existing appreciation idea is preserved, not deleted.
+
+Entering Appreciation Camera:
+
+- hides most nonessential UI;
+- shifts framing toward sea/horizon;
+- may place the avatar/pet at the edge or temporarily out of frame;
+- does not stop the voyage timer or soundscape;
+- does not increase rewards.
+
+This keeps the previous Resting Core investment useful while allowing a visible player character during normal play.
+
+### Avatar MVP
+
+Visible avatar customization starts with only:
+
+- body/base preset;
+- hair;
+- top;
+- bottom;
+- head accessory;
+- one small accessory slot;
+- color variants.
+
+No stat bonuses are attached to cosmetics.
+
+Avatar low-pressure actions:
+
+- sit;
+- rest/lie down where supported;
+- lean on rail;
+- look at sea;
+- hold cup;
+- view album;
+- read/write bottle letter;
+- fish;
+- pet companion.
+
+---
+
+## 4. Boat decoration design
+
+### Selected approach: slot-zone decoration
+
+Use explicit decoration zones instead of a freeform 3D editor for the first implementation.
+
+Recommended initial zones:
+
+1. bow-left;
+2. bow-right;
+3. center-left;
+4. center-right;
+5. rear-left;
+6. rear-right;
+7. wall/rail accent;
+8. pet corner.
+
+Each zone accepts a small compatible category set.
+
+### Why this approach
+
+- predictable touch controls on portrait mobile;
+- lower overlap/clipping complexity;
+- lower save-data complexity;
+- easier camera composition;
+- easier to keep the boat visually calm;
+- compatible with later upgrade to constrained free placement if Human tests justify it.
+
+### Decoration reward rule
+
+Decor should represent memory and self-expression, not power.
+
+Good examples:
+
+- lantern;
+- mug;
+- cushion;
+- blanket;
+- plant;
+- framed voyage photo;
+- shell;
+- postcard;
+- bottle shelf;
+- pet cushion.
+
+Rejected as core:
+
+- rarity score;
+- decoration DPS/stat bonuses;
+- gacha pressure;
+- daily limited shops;
+- optimization bonuses for filling every slot.
+
+---
+
+## 5. Interaction architecture
+
+Create one reusable interaction contract instead of implementing each prop as a special case.
+
+Conceptual interface:
+
+```text
+Interactable
+- get_actions(actor_context) -> Array[InteractionAction]
+- can_interact(actor_context, action_id) -> bool
+- perform(actor_context, action_id) -> InteractionResult
+```
+
+Examples:
+
+- pet → pet / sit together / look at sea;
+- rail → lean / look at sea;
+- cushion → sit;
+- lantern → turn on/off;
+- cup → hold / put down;
+- album → open;
+- fishing rod → start quiet fishing;
+- bottle station → write bottle / check arrivals.
+
+Interaction constraints:
+
+- no rapid repeated tapping for progression;
+- no failure penalty for ignoring interactions;
+- no interaction that forces the player to interrupt Appreciation Camera;
+- repeated interactions may vary animation/dialogue but must not become optimal farming.
+
+---
+
+## 6. Delayed Bottle Social overview
+
+The social feature is deliberately **not realtime chat**.
+
+### Common properties
+
+- text only in MVP;
+- maximum 400 Unicode characters per letter;
+- one optional sticker from a developer-curated sticker set;
+- no user photo/file/audio attachment in MVP;
+- no typing indicator;
+- no online/presence indicator;
+- no read receipt;
+- no public profile browsing;
+- no follower/following counts;
+- no public feed;
+- no global chat;
+- no ranking or popularity score;
+- every sent message travels through a server-side delivery pipeline.
+
+### Healthy-backend delivery target
+
+`TARGET_DELIVERY <= 5 minutes` means the message is **server-receivable** by the recipient under healthy backend/network conditions.
+
+It does not guarantee a visible phone notification within 5 minutes if the recipient is offline, the app is closed, or backend/network service is degraded.
+
+Selected timing:
+
+```text
+server moderation/validation budget: <= 5 sec normal path
+deliver_at offset: random 45..210 sec
+active-client poll interval: 20..30 sec
+healthy-path worst target: normally <= 245 sec
+safety margin to product target: 55 sec
+```
+
+The random delay is intentional product behavior, not technical latency.
+
+---
+
+## 7. FriendBottle
+
+### Purpose
+
+Slow correspondence with a known in-game friend without turning the game into a messenger.
+
+### Identity
+
+Friend relationships require a **durable linked account**. An anonymous temporary account may play the local game and use offline systems, but must be linked before creating a durable friend relation.
+
+Allowed durable login methods can be implemented incrementally, but the architecture must support linking the existing anonymous account instead of replacing its user id.
+
+### Flow
+
+```text
+select friend
+→ write <= 400 chars + optional curated sticker
+→ server validation/moderation
+→ deliver_at assigned 45..210 sec later
+→ stored in friend's inbox
+→ active client discovers it at next poll
+→ friend may reply with another delayed bottle
+```
+
+FriendBottle still has delay. It must not become an instant-message bypass.
+
+Rate limit baseline:
+
+- max 10 FriendBottle sends per hour;
+- max 50 FriendBottle sends per day;
+- server-enforced, not client-only.
+
+---
+
+## 8. DriftBottle for unknown users
+
+### Purpose
+
+Create the feeling that a letter drifted from another quiet boat, not that the player entered random chat.
+
+### Eligibility
+
+MVP safety profile:
+
+- Terms/Community Guidelines accepted;
+- self-declared age **16+** for stranger matching;
+- account at least 10 minutes old;
+- at least one completed 5-minute voyage;
+- not currently rate-limited or restricted;
+- client may be anonymous-authenticated, but server identity is still a unique authenticated user id.
+
+Declared users under 16 do not receive/send `DriftBottle`; they may use local systems and, where account policy allows, `FriendBottle` only.
+
+### Stranger identity
+
+The recipient does not receive the sender's durable account identifier or global profile.
+
+Each stranger correspondence gets an ephemeral server-generated pen-name, for example adjective+nature-noun+number. The alias is scoped to that correspondence only.
+
+No search can resolve that alias back to a global account.
+
+### Matching
+
+Server selects an eligible recipient who:
+
+- is not the sender;
+- is not blocked in either direction;
+- has not been recently over-matched with the sender;
+- is eligible for stranger bottles;
+- is within inbox capacity limits.
+
+### Limited stranger correspondence
+
+A stranger pairing may exchange at most **3 round trips** (maximum six letters total) before continuation requires a mutual friend opt-in.
+
+At the limit:
+
+- either side may end silently;
+- either side may request `Continue as friends`;
+- only if both independently accept does the relationship become a durable `Friendship`;
+- no external contact information is revealed automatically.
+
+This intentionally prevents infinite anonymous-chat threads.
+
+Rate limit baseline:
+
+- max 3 new DriftBottle sends per hour;
+- max 10 new DriftBottle sends per day;
+- replies count toward the same stranger-social budget;
+- server-enforced.
+
+---
+
+## 9. Safety, moderation, and store compliance
+
+Bottle letters are UGC. Safety is a release requirement, not post-launch cleanup.
+
+### Required before public stranger matching
+
+- Terms of Use / Community Guidelines acceptance before sending UGC;
+- clearly defined prohibited content;
+- server-side pre-publication filtering;
+- report content;
+- report user;
+- block user;
+- immediate local hide after report/block;
+- moderation review queue;
+- developer contact/support path;
+- data retention/deletion policy;
+- age gating described above;
+- abuse/rate limiting;
+- audit receipt for moderation action.
+
+### Content restrictions in MVP
+
+Block or quarantine:
+
+- URLs;
+- email addresses;
+- phone numbers;
+- obvious social handles / external contact exchange patterns;
+- sexual solicitation;
+- threats;
+- targeted harassment;
+- hate/abusive content;
+- self-harm encouragement;
+- exploitation/grooming patterns;
+- spam/repetition patterns.
+
+### Moderation pipeline
+
+```text
+send request
+→ authentication + eligibility
+→ normalization
+→ length/sticker schema validation
+→ contact/URL deterministic filter
+→ rate limit
+→ server-side semantic moderation adapter
+→ ALLOW / REJECT / QUARANTINE
+→ only ALLOW enters delivery queue
+```
+
+The semantic moderation adapter is server-only. Godot never contains a provider secret.
+
+**Release gate:** `DriftBottle` remains server-feature-flag OFF unless a production moderation adapter, report/block flow, and moderation operation path are all working in the deployed environment.
+
+### App-review positioning
+
+The product must remain a rest/boat/decor game with an incidental bottle-letter feature. Do not redesign the home screen or marketing so random stranger communication becomes the app's primary purpose.
+
+References checked during design:
+
+- Apple App Review Guidelines 1.2 User-Generated Content, including 2026 clarification for random/anonymous chat.
+- Google Play Developer Program UGC policy requiring terms, moderation, in-app report and block.
+
+---
+
+## 10. Backend trade study
+
+### A. Supabase — SELECTED FOR MVP
+
+Provides in one stack:
+
+- anonymous Auth;
+- account linking path;
+- Postgres relational model;
+- Row Level Security;
+- Edge Functions;
+- enough free-tier capacity for development and small closed testing.
+
+Current published Free-plan reference at design time:
+
+- 500 MB database per project;
+- 50,000 MAU;
+- 500,000 Edge Function invocations;
+- 2 million Realtime messages;
+- Free projects may pause after one week of inactivity.
+
+We **do not need Supabase Realtime for bottle delivery**. Polling is selected because it supports the product fiction and reduces complexity.
+
+Risk: Free-plan pause means the 5-minute target cannot be treated as a hard uptime SLA on a dormant free project. Public-launch hosting is a separate deployment Gate.
+
+### B. Cloudflare Workers + D1 — STRONG ZERO-COST ALTERNATIVE
+
+Current free reference at design time:
+
+- Workers: 100,000 requests/day;
+- D1: 5 million rows read/day;
+- D1: 100,000 rows written/day;
+- 5 GB total free D1 storage;
+- no equivalent inactivity pause, but daily limits fail closed when exhausted.
+
+Advantages:
+
+- excellent small-service cost profile;
+- explicit server function layer;
+- good fit for a narrow bottle service.
+
+Disadvantages:
+
+- no integrated user/friend authentication model comparable to Supabase Auth+RLS;
+- more custom security/account work;
+- increases implementation surface for a solo project.
+
+Decision: keep as migration/fallback option if Supabase operational cost or pause behavior becomes a real release problem.
+
+### C. Firebase Auth + Firestore — REJECT FOR CURRENT MVP
+
+Current free Firestore reference:
+
+- 1 GiB storage;
+- 50,000 document reads/day;
+- 20,000 document writes/day;
+- 10 GiB outbound/month;
+- anonymous authentication supported.
+
+Advantages:
+
+- mature mobile auth;
+- straightforward anonymous-to-linked account path.
+
+Disadvantages:
+
+- message/friend/report relations are less natural than Postgres for this design;
+- server-side moderation/routing adds another function/deployment concern;
+- cost behavior is read/write-operation centered and easier to make noisy with polling if queries are poorly structured.
+
+Decision: not selected.
+
+---
+
+## 11. Selected backend architecture
+
+```text
+Godot 4.7
+├─ local voyage / pet / decor / album / fishing / soundscape
+├─ SocialSession
+│  ├─ anonymous auth bootstrap
+│  ├─ linked-account state
+│  └─ feature eligibility
+└─ BottleClient
+   ├─ send_friend_bottle()
+   ├─ send_drift_bottle()
+   ├─ poll_inbox()
+   ├─ reply()
+   ├─ report()
+   ├─ block()
+   └─ request_friendship()
+        │
+        ▼
+Supabase
+├─ Auth
+├─ Postgres + RLS
+├─ Edge Functions
+│  ├─ send-bottle
+│  ├─ poll-inbox
+│  ├─ bottle-action
+│  ├─ friendship-action
+│  └─ moderation/report intake
+└─ tables
+   ├─ profiles
+   ├─ social_consents
+   ├─ friendships
+   ├─ bottle_threads
+   ├─ bottles
+   ├─ blocks
+   ├─ reports
+   └─ moderation_actions
+```
+
+Do not expose direct table write access for sensitive social state when an Edge Function can enforce the full invariant atomically.
+
+---
+
+## 12. Data model
+
+### `profiles`
+
+- `user_id uuid primary key` → auth user;
+- `display_name text` → visible only where policy allows;
+- `age_bucket enum('under16','16plus')`;
+- `social_status enum('local_only','stranger_eligible','restricted')`;
+- `created_at timestamptz`;
+- `linked_identity boolean`.
+
+### `social_consents`
+
+- `user_id uuid`;
+- `terms_version text`;
+- `community_version text`;
+- `accepted_at timestamptz`;
+- primary key `(user_id, terms_version, community_version)`.
+
+### `friendships`
+
+- canonical ordered pair `user_a`, `user_b`;
+- `status enum('pending','accepted','ended')`;
+- `requested_by uuid`;
+- timestamps;
+- unique pair constraint.
+
+### `bottle_threads`
+
+- `id uuid`;
+- `kind enum('friend','stranger')`;
+- `participant_a uuid`;
+- `participant_b uuid`;
+- `stranger_alias_a text nullable`;
+- `stranger_alias_b text nullable`;
+- `round_trip_count int default 0`;
+- `state enum('open','friendship_gate','closed','blocked')`;
+- timestamps.
+
+### `bottles`
+
+- `id uuid`;
+- `thread_id uuid`;
+- `sender_id uuid`;
+- `recipient_id uuid`;
+- `body text`;
+- `sticker_id text nullable`;
+- `created_at timestamptz`;
+- `deliver_at timestamptz`;
+- `delivered_at timestamptz nullable`;
+- `read_at timestamptz nullable`;
+- `moderation_state enum('allow','reject','quarantine')`;
+- `status enum('queued','available','read','deleted','expired')`.
+
+Database constraints must enforce `length <= 400` at the storage boundary as well as the Edge Function.
+
+### `blocks`
+
+- blocker user;
+- blocked user;
+- timestamp;
+- unique pair.
+
+A block immediately prevents future matching, thread continuation, and friend sends in both delivery checks and routing.
+
+### `reports`
+
+- reporter;
+- reported user;
+- bottle id;
+- reason enum;
+- freeform detail optional and length-limited;
+- status;
+- created timestamp.
+
+### `moderation_actions`
+
+- report/bottle reference;
+- action enum;
+- actor/system identifier;
+- reason code;
+- timestamp.
+
+---
+
+## 13. RLS and access boundaries
+
+Minimum principles:
+
+- users can read their own profile and only approved public friend-facing fields of accepted friends;
+- users can read bottle content only when they are sender or recipient;
+- client cannot arbitrarily assign `recipient_id` for stranger matching;
+- client cannot set `moderation_state=allow`;
+- client cannot shorten `deliver_at`;
+- client cannot bypass rate limits by writing directly to `bottles`;
+- blocked relationships are checked server-side before every route/send;
+- moderation/report tables are not broadly readable;
+- service-role credentials never ship in Godot.
+
+Use authenticated user JWTs. Anonymous Auth users are still authenticated identities and must be distinguished by claim/account state where social policy requires it.
+
+---
+
+## 14. Offline and failure behavior
+
+### Sending while offline
+
+- local draft may be saved;
+- UI says the bottle has **not left the boat yet**;
+- retry only after connectivity returns;
+- do not fabricate a `deliver_at` before server acceptance.
+
+### Recipient offline
+
+- bottle becomes available in server inbox at/after `deliver_at`;
+- it remains unread until next successful poll/session;
+- no push notification is required in MVP.
+
+### Moderation unavailable
+
+- fail closed for `DriftBottle`;
+- FriendBottle may also fail closed until the required production safety policy says otherwise;
+- never silently route an unmoderated stranger message.
+
+### Backend paused/degraded
+
+- client shows a calm non-urgent state such as "오늘은 바다가 조금 멀리 흐르고 있어요";
+- no streak or reward loss;
+- local voyage/rest loop remains fully playable.
+
+---
+
+## 15. Privacy and data minimization
+
+MVP social backend should not require:
+
+- phone contacts;
+- precise location;
+- address book upload;
+- public social graph;
+- real-world name;
+- user photos;
+- voice data.
+
+The bottle subsystem stores only what is necessary for authentication, social eligibility, routing, content moderation, blocking/reporting, and user-requested friendship.
+
+External contact exchange is filtered in stranger correspondence so an ephemeral stranger alias does not become an accidental doxxing channel.
+
+---
+
+## 16. Integration with the rest loop
+
+Bottle social must remain ambient.
+
+### Arrival presentation
+
+Do not use a loud push-style popup while the player is resting.
+
+Preferred in-game treatment:
+
+- a bottle quietly appears near the boat / bottle basket;
+- small optional visual indicator;
+- no countdown;
+- no "reply now" pressure;
+- unread bottles persist until the player chooses to read them.
+
+### Rewards
+
+Receiving or replying to human bottles must not grant an economy advantage large enough to force social play.
+
+Permissible soft rewards:
+
+- memory entry;
+- decorative postcard frame;
+- album log;
+- optional cosmetic sticker unlock after broad milestones.
+
+Rejected:
+
+- daily reply streak;
+- social currency farming;
+- rarity ranking;
+- response-time bonus;
+- public popularity score.
+
+---
+
+## 17. Implementation decomposition after spec review
+
+This architecture is too broad for one implementation PR. It must be split into independently testable slices.
+
+Recommended order:
+
+1. **Canon migration + Diorama camera/visible avatar shell**  
+   Update AGENTS/Notion/repository direction, preserve Appreciation Camera, add avatar placeholder and camera contract. No backend.
+
+2. **Local decoration + Interactable contract**  
+   Slot zones, local save model, 3–5 representative props, pet/rail/cup interactions. No online dependency.
+
+3. **Social fake-backend contract**  
+   Godot `BottleClient` interface + deterministic local fake implementing delayed FriendBottle/DriftBottle state transitions, tests for 5-minute target semantics, report/block, thread limits. No real cloud dependency yet.
+
+4. **Supabase schema/Auth/RLS/Edge Functions**  
+   Local Supabase development environment first, migration SQL, tests for unauthorized reads/writes, rate limits, delivery scheduling, block routing, stranger round-trip gate.
+
+5. **Production moderation + release feature gate**  
+   Server-side moderation adapter, terms acceptance, report queue, block/report UX. Stranger matching remains OFF until this slice passes.
+
+6. **End-to-end delayed bottle integration**  
+   Replace fake backend with real adapter under the same client interface; polling; offline drafts; friend linking; healthy-path delivery timing evidence.
+
+7. **Human/device social-rest validation**  
+   Verify bottle arrival feels ambient, not urgent; verify moderation/report/block discoverability; verify 5-minute target in real network conditions; verify local rest remains functional during backend failure.
+
+Each slice gets its own TDD red/green cycle, PR, exact-head CI, adversarial review, and Notion sync.
+
+---
+
+## 18. Acceptance criteria for the architecture
+
+The future implementation is only faithful to this design if all are true:
+
+- normal gameplay visibly shows the player avatar and pet in a 3/4 boat diorama;
+- Appreciation Camera still offers a low-UI sea-focused rest view;
+- decoration has no stats or mandatory optimization;
+- object/pet interactions are optional and low-pressure;
+- FriendBottle and DriftBottle are delayed rather than realtime;
+- healthy backend design keeps active-client server receipt under the 5-minute target;
+- stranger communication has no directory, presence, typing, read receipt, or public feed;
+- stranger thread cannot continue indefinitely without mutual friend consent;
+- declared under-16 users cannot use stranger matching in the MVP safety profile;
+- reports and blocks are accessible in-app;
+- blocked users cannot be re-matched or deliver new bottles;
+- UGC moderation happens server-side before stranger delivery;
+- local voyage/rest/decor remains playable if social backend is unavailable;
+- no service-role or moderation-provider secret ships in the Godot client;
+- `DriftBottle` cannot be enabled for public release without the safety release gate.
+
+---
+
+## 19. Explicit non-goals
+
+Not part of this design:
+
+- realtime chat;
+- voice/video chat;
+- public timeline/feed;
+- social follower system;
+- location-based matching;
+- dating/matchmaking mechanics;
+- competitive popularity;
+- online co-op movement in the same boat world;
+- marketplace/trading;
+- user-uploaded images/audio/files in bottle letters;
+- unrestricted external contact exchange;
+- backend dependency for basic single-player rest gameplay.
+
+---
+
+## 20. Design decision summary
+
+**Selected product architecture:** `Rest-first Bondee Boat Diorama + Delayed Bottle Social`.
+
+**Selected camera architecture:** 3/4 visible-avatar diorama for normal play + preserved Appreciation Camera for sea-focused rest.
+
+**Selected decoration architecture:** fixed slot zones first.
+
+**Selected interaction architecture:** reusable Interactable contract.
+
+**Selected social model:** delayed FriendBottle + rate-limited/limited-thread DriftBottle; mutual consent required to convert strangers into friends.
+
+**Selected backend for MVP:** Supabase Auth + Postgres/RLS + Edge Functions, with polling instead of Realtime.
+
+**Selected safety posture:** stranger matching is an incidental, gated UGC subsystem and remains disabled until production moderation/report/block/terms operations are deployable.
+
+**Selected cost posture:** develop on free/local-first infrastructure; re-evaluate hosting before public launch if Supabase Free pause/limits conflict with real delivery reliability.

--- a/docs/superpowers/specs/2026-08-24-bondee-diorama-delayed-bottle-design.md
+++ b/docs/superpowers/specs/2026-08-24-bondee-diorama-delayed-bottle-design.md
@@ -210,6 +210,8 @@ product-target margin: >= 55 sec
 
 Random delay is product behavior, not accidental latency.
 
+**No cron/scheduler is required for MVP availability.** `poll-inbox` treats any allowed bottle with `deliver_at <= server_now` as available and may atomically stamp `delivered_at` on first retrieval. The database timestamp is the source of truth; the client cannot shorten the delay.
+
 ---
 
 ## 7. Social eligibility and durable identity
@@ -243,13 +245,15 @@ No public user search.
 Use a server-generated **8-character one-time Friend Invite Code**:
 
 - expires after 24 hours;
-- single-use after successful acceptance;
 - generated only for `linked_social` users;
 - code itself reveals no email or auth id;
-- accepting the code creates a pending friendship request;
-- friendship becomes accepted only after the receiving account confirms.
+- the code owner is the inviter;
+- a second linked user redeems the code as the invitee;
+- redemption consumes the code and records the invitee's consent;
+- the inviter must then explicitly confirm the pending request before `friendships.status` becomes `accepted`;
+- raw code is shown only at creation time and the database stores only its hash.
 
-A new `friend_invites` table stores only the hash of the active code, owner, expiry, use state, and timestamps.
+This extra inviter-confirm step prevents a leaked code from silently creating a durable friendship.
 
 ### FriendBottle flow
 
@@ -526,7 +530,9 @@ Sensitive social state is mutated through Edge Functions when full invariants mu
 - `owner_id uuid`;
 - `code_hash text unique`;
 - `expires_at timestamptz`;
-- `used_at timestamptz nullable`;
+- `redeemed_by uuid nullable`;
+- `redeemed_at timestamptz nullable`;
+- `confirmed_at timestamptz nullable`;
 - `created_at timestamptz`.
 
 Raw invite codes are returned once to the owner and are not stored in plaintext.
@@ -624,8 +630,8 @@ Block immediately prevents matching, thread continuation, and friend delivery.
 
 ### Recipient offline
 
-- bottle becomes available server-side at/after `deliver_at`;
-- remains unread until future poll/session;
+- bottle becomes available server-side when `deliver_at <= server_now`;
+- remains unread until a future poll/session;
 - no push notification required in MVP.
 
 ### Moderation unavailable
@@ -691,13 +697,13 @@ This architecture is intentionally split into testable slices rather than one gi
    Godot `BottleClient` interface + deterministic local fake implementing delayed FriendBottle/DriftBottle transitions, 5-minute acceptance semantics, report/block, invite-code, age gate, and 6-letter stranger limit.
 
 4. **Supabase schema/Auth/RLS/Edge Functions**  
-   Local Supabase development first, SQL migrations, anonymous→email-OTP link, RLS/security tests, rate limits, delivery scheduling, block routing, invite flow, stranger gate.
+   Local Supabase development first, SQL migrations, anonymous→email-OTP link, RLS/security tests, rate limits, delivery timestamp semantics, block routing, invite flow, stranger gate.
 
 5. **Production moderation + release gate**  
    Separate focused design/benchmark for the concrete semantic moderation provider, then implement Terms, report queue, block/report UX and feature gating. `DriftBottle` remains OFF until this passes.
 
 6. **End-to-end delayed bottle integration**  
-   Replace fake adapter with real adapter under same client interface; polling; offline drafts; friendship; delivery evidence.
+   Replace fake adapter with real adapter under the same client interface; polling; offline drafts; friendship; delivery evidence.
 
 7. **Human/device social-rest validation**  
    Verify arrivals feel ambient, safety actions are discoverable, delivery target holds on real networks, and backend failure never blocks rest gameplay.
@@ -719,6 +725,7 @@ Implementation is faithful only if:
 - no-recipient DriftBottle is not falsely accepted;
 - all online social is 16+ in MVP;
 - FriendInvite codes are one-time, 8-character, 24-hour and server-generated;
+- FriendInvite redemption does not create an accepted friendship until the inviter confirms;
 - stranger mode has no directory, presence, typing, read receipt, or public feed;
 - stranger thread stops at 6 letters unless mutual friendship consent succeeds;
 - report and block are in-app;
@@ -754,9 +761,9 @@ Implementation is faithful only if:
 - Decoration: fixed slot zones first.
 - Interaction: reusable `Interactable` contract.
 - Social age: all online social 16+ for MVP.
-- Friend discovery: durable linked account + one-time 8-char/24h Friend Invite Code.
+- Friend discovery: durable linked account + one-time 8-char/24h Friend Invite Code + inviter confirm after redemption.
 - Stranger social: delayed/rate-limited `DriftBottle`, server-assigned ephemeral alias, max 6 letters, mutual consent to become friends.
-- Delivery: accepted bottles use 45..210 sec intentional delay + 20..30 sec polling, target <=5 min under healthy conditions.
+- Delivery: accepted bottles use 45..210 sec intentional delay + 20..30 sec polling; `poll-inbox` resolves `deliver_at <= server_now`; target <=5 min under healthy conditions.
 - MVP backend: Supabase Auth + Postgres/RLS + Edge Functions, polling instead of Realtime.
 - Safety: stranger mode remains OFF until semantic moderation + Terms + report/block + operations are deployed/tested.
 - Cost: local/free-first development; hosting tier is re-Gated before public release if Supabase Free pause/limits conflict with real reliability.

--- a/docs/superpowers/specs/2026-08-24-bondee-diorama-delayed-bottle-design.md
+++ b/docs/superpowers/specs/2026-08-24-bondee-diorama-delayed-bottle-design.md
@@ -7,9 +7,9 @@ Base repository main at design start: `b6949a0b92f591bc099a5cf143b9fe32a863e45f`
 
 ## 0. Authority and migration note
 
-This design captures the user's latest approved product direction and therefore supersedes the older product assumptions that the game must be first-person-only, that the player body must never be visible, and that online bottle-letter sharing is forbidden.
+This design records the user's latest approved product direction and supersedes the older assumptions that the game must be first-person-only, the player body must never be visible, and online bottle-letter sharing is forbidden.
 
-The current `AGENTS.md` still contains those older constraints. **Do not implement against the new design by silently ignoring `AGENTS.md`.** The first implementation slice must update the project operating canon explicitly, then move runtime work forward under the new authority.
+The current `AGENTS.md` still contains those older constraints. The first implementation slice must update that operating canon explicitly before runtime work adopts this design. Do not silently ignore the old rules.
 
 Notion remains the human-facing design canon. Repository Markdown is the structured implementation mirror. Runtime claims still require Godot/code/test evidence.
 
@@ -17,20 +17,18 @@ Notion remains the human-facing design canon. Repository Markdown is the structu
 
 ## 1. Product North Star
 
-### One sentence
-
 **A small storybook boat diorama where the player's visible avatar and pet quietly live, decorate, rest, and exchange slowly drifting bottle letters without turning the experience into a realtime social network.**
 
-### Emotional priority
+Emotional priority:
 
 1. Rest and comfort.
-2. Personal attachment to avatar, pet, and boat.
+2. Attachment to avatar, pet, and boat.
 3. A sense that the boat is "my small place".
 4. Gentle object and pet interaction.
 5. Unexpected human warmth through bottle letters.
-6. Collection and customization as memory, not optimization.
+6. Collection/customization as memory, not optimization.
 
-No new system may make efficiency, urgency, social status, streaks, FOMO, ranking, or response pressure more important than the above order.
+Efficiency, urgency, social status, streaks, FOMO, ranking, or response pressure never outrank those goals.
 
 ---
 
@@ -38,53 +36,48 @@ No new system may make efficiency, urgency, social status, streaks, FOMO, rankin
 
 ### Before
 
-- Primary presentation: first-person sea appreciation.
-- Player body not visible.
-- Boat mainly functions as viewpoint/container.
-- Bottle letters are authored ambient content only.
-- Online social exchange prohibited.
+- first-person sea appreciation is the primary presentation;
+- player body not visible;
+- boat mainly functions as viewpoint/container;
+- bottle letters are authored ambient content only;
+- online social exchange prohibited.
 
 ### After
 
-- Primary presentation: **3/4 diorama camera** showing the player's avatar, pet, boat, decorations, and sea together.
-- Optional **Appreciation Camera** preserves the existing close sea-view/first-person-like relaxation mode.
-- Boat becomes a personal living space with low-pressure decoration and interaction.
-- Bottle letters become two systems:
-  - `FriendBottle`: delayed direct correspondence with an accepted friend.
-  - `DriftBottle`: delayed, limited correspondence with an unknown user.
-- Online scope stays isolated to social identity + bottle delivery + safety operations. Voyage, pet, decoration, album, fishing, soundscape, and rest loop remain local-first.
+- primary presentation becomes a **3/4 diorama camera** showing avatar + pet + boat + decorations + sea;
+- optional **Appreciation Camera** preserves the current sea-focused/first-person-like relaxation mode;
+- boat becomes a personal living space with low-pressure decoration and interaction;
+- bottle letters split into `FriendBottle` and `DriftBottle`;
+- online scope stays isolated to social identity, bottle delivery, friendship, and safety operations;
+- voyage, pet, decoration, album, fishing, soundscape, and rest loop remain local-first.
 
 ---
 
-## 3. Camera and avatar design
+## 3. Camera and avatar
 
-### Primary camera: 3/4 Boat Diorama
+### Primary camera — 3/4 Boat Diorama
 
-Requirements:
-
-- Show avatar + pet + useful portion of boat + horizon in one calm composition.
-- Keep camera movement slow, bounded, and predictable.
-- Mobile portrait remains the primary screen constraint.
-- Camera should not constantly follow tiny avatar movement with aggressive easing.
-- The player's decorations must remain readable without covering the sea.
+- Show avatar, pet, useful boat area, and horizon together.
+- Camera movement is slow, bounded, and predictable.
+- Mobile portrait remains the primary composition constraint.
+- Do not aggressively chase tiny avatar movement.
+- Decorations stay readable without hiding the sea.
 
 ### Appreciation Camera
-
-The existing appreciation idea is preserved, not deleted.
 
 Entering Appreciation Camera:
 
 - hides most nonessential UI;
 - shifts framing toward sea/horizon;
-- may place the avatar/pet at the edge or temporarily out of frame;
-- does not stop the voyage timer or soundscape;
-- does not increase rewards.
+- may place avatar/pet at edge or temporarily out of frame;
+- keeps voyage timer and soundscape running;
+- changes no rewards.
 
-This keeps the previous Resting Core investment useful while allowing a visible player character during normal play.
+This preserves the current Resting Core investment instead of throwing it away.
 
 ### Avatar MVP
 
-Visible avatar customization starts with only:
+Customization starts with:
 
 - body/base preset;
 - hair;
@@ -94,9 +87,9 @@ Visible avatar customization starts with only:
 - one small accessory slot;
 - color variants.
 
-No stat bonuses are attached to cosmetics.
+Cosmetics have no stats.
 
-Avatar low-pressure actions:
+Low-pressure actions:
 
 - sit;
 - rest/lie down where supported;
@@ -110,13 +103,13 @@ Avatar low-pressure actions:
 
 ---
 
-## 4. Boat decoration design
+## 4. Boat decoration
 
-### Selected approach: slot-zone decoration
+### Selected approach — slot-zone decoration
 
-Use explicit decoration zones instead of a freeform 3D editor for the first implementation.
+Use explicit zones instead of a freeform 3D editor in the first implementation.
 
-Recommended initial zones:
+Initial zones:
 
 1. bow-left;
 2. bow-right;
@@ -127,49 +120,26 @@ Recommended initial zones:
 7. wall/rail accent;
 8. pet corner.
 
-Each zone accepts a small compatible category set.
+Each zone accepts only compatible categories.
 
-### Why this approach
+Why selected:
 
-- predictable touch controls on portrait mobile;
-- lower overlap/clipping complexity;
-- lower save-data complexity;
-- easier camera composition;
-- easier to keep the boat visually calm;
-- compatible with later upgrade to constrained free placement if Human tests justify it.
+- predictable portrait-mobile touch controls;
+- lower clipping/overlap complexity;
+- simpler save data;
+- easier calm camera composition;
+- lower solo-development cost;
+- can later evolve into constrained free placement if Human tests justify it.
 
-### Decoration reward rule
+Good decor: lantern, mug, cushion, blanket, plant, framed voyage photo, shell, postcard, bottle shelf, pet cushion.
 
-Decor should represent memory and self-expression, not power.
-
-Good examples:
-
-- lantern;
-- mug;
-- cushion;
-- blanket;
-- plant;
-- framed voyage photo;
-- shell;
-- postcard;
-- bottle shelf;
-- pet cushion.
-
-Rejected as core:
-
-- rarity score;
-- decoration DPS/stat bonuses;
-- gacha pressure;
-- daily limited shops;
-- optimization bonuses for filling every slot.
+Rejected as core: rarity score, stat bonuses, gacha pressure, daily limited shops, optimization bonuses for filling every slot.
 
 ---
 
 ## 5. Interaction architecture
 
-Create one reusable interaction contract instead of implementing each prop as a special case.
-
-Conceptual interface:
+Use one reusable interaction contract instead of one-off prop scripts.
 
 ```text
 Interactable
@@ -189,176 +159,211 @@ Examples:
 - fishing rod → start quiet fishing;
 - bottle station → write bottle / check arrivals.
 
-Interaction constraints:
+Constraints:
 
-- no rapid repeated tapping for progression;
-- no failure penalty for ignoring interactions;
-- no interaction that forces the player to interrupt Appreciation Camera;
-- repeated interactions may vary animation/dialogue but must not become optimal farming.
+- no rapid-tap progression;
+- ignoring interactions never causes loss;
+- interactions never force exit from Appreciation Camera;
+- animation/dialogue variation may exist but cannot become optimal farming.
 
 ---
 
-## 6. Delayed Bottle Social overview
+## 6. Delayed Bottle Social common contract
 
-The social feature is deliberately **not realtime chat**.
+This is deliberately **not realtime chat**.
 
-### Common properties
+MVP message shape:
 
-- text only in MVP;
-- maximum 400 Unicode characters per letter;
-- one optional sticker from a developer-curated sticker set;
-- no user photo/file/audio attachment in MVP;
-- no typing indicator;
-- no online/presence indicator;
-- no read receipt;
-- no public profile browsing;
-- no follower/following counts;
-- no public feed;
-- no global chat;
-- no ranking or popularity score;
-- every sent message travels through a server-side delivery pipeline.
+- text only;
+- maximum 400 Unicode characters;
+- one optional developer-curated sticker;
+- no user image/file/audio attachment.
+
+Explicitly absent:
+
+- typing indicator;
+- online/presence indicator;
+- read receipt;
+- public profile browsing;
+- follower counts;
+- public feed;
+- global chat;
+- popularity/ranking score.
+
+Every message passes through a server-side delivery/safety pipeline.
 
 ### Healthy-backend delivery target
 
-`TARGET_DELIVERY <= 5 minutes` means the message is **server-receivable** by the recipient under healthy backend/network conditions.
+`TARGET_DELIVERY <= 5 minutes` means an **accepted** bottle becomes server-receivable by its assigned recipient within 5 minutes under healthy backend/network conditions.
 
-It does not guarantee a visible phone notification within 5 minutes if the recipient is offline, the app is closed, or backend/network service is degraded.
+It does not guarantee a visible phone notification if the recipient is offline, app-closed, or the backend/network is degraded.
 
-Selected timing:
+Timing contract:
 
 ```text
-server moderation/validation budget: <= 5 sec normal path
-deliver_at offset: random 45..210 sec
+normal moderation/validation budget: <= 5 sec
+deliver_at offset after acceptance: random 45..210 sec
 active-client poll interval: 20..30 sec
-healthy-path worst target: normally <= 245 sec
-safety margin to product target: 55 sec
+normal healthy-path upper target: <= 245 sec
+product-target margin: >= 55 sec
 ```
 
-The random delay is intentional product behavior, not technical latency.
+Random delay is product behavior, not accidental latency.
 
 ---
 
-## 7. FriendBottle
+## 7. Social eligibility and durable identity
 
-### Purpose
+### MVP age policy
 
-Slow correspondence with a known in-game friend without turning the game into a messenger.
+To avoid an ambiguous child-safety implementation, **all online social sending/receiving is 16+ in the MVP**.
 
-### Identity
+- declared under-16 users can use the full local rest/decor/pet/voyage game;
+- declared under-16 users cannot send/receive `FriendBottle` or `DriftBottle` in MVP;
+- lowering this threshold is a separate future policy/design change, not an implementation shortcut.
 
-Friend relationships require a **durable linked account**. An anonymous temporary account may play the local game and use offline systems, but must be linked before creating a durable friend relation.
+### Account stages
 
-Allowed durable login methods can be implemented incrementally, but the architecture must support linking the existing anonymous account instead of replacing its user id.
+1. `local_only` — no social account required for core game.
+2. `anonymous_social` — Supabase anonymous Auth creates a unique authenticated server identity for limited `DriftBottle` eligibility.
+3. `linked_social` — durable account link required for friendships and `FriendBottle`.
 
-### Flow
+MVP durable link method: **email OTP**. Platform OAuth can be added later without changing the user id.
+
+Anonymous identity must be linked, not replaced, when upgraded.
+
+---
+
+## 8. Friend discovery and FriendBottle
+
+### Adding a friend
+
+No public user search.
+
+Use a server-generated **8-character one-time Friend Invite Code**:
+
+- expires after 24 hours;
+- single-use after successful acceptance;
+- generated only for `linked_social` users;
+- code itself reveals no email or auth id;
+- accepting the code creates a pending friendship request;
+- friendship becomes accepted only after the receiving account confirms.
+
+A new `friend_invites` table stores only the hash of the active code, owner, expiry, use state, and timestamps.
+
+### FriendBottle flow
 
 ```text
-select friend
-→ write <= 400 chars + optional curated sticker
-→ server validation/moderation
-→ deliver_at assigned 45..210 sec later
-→ stored in friend's inbox
-→ active client discovers it at next poll
-→ friend may reply with another delayed bottle
+select accepted friend
+→ write <= 400 chars + optional sticker
+→ server safety validation
+→ deliver_at = accepted_at + random(45..210 sec)
+→ friend inbox
+→ active client discovers at next poll
+→ optional delayed reply
 ```
 
-FriendBottle still has delay. It must not become an instant-message bypass.
+Still delayed; no instant-message bypass.
 
-Rate limit baseline:
+Baseline server rate limits:
 
-- max 10 FriendBottle sends per hour;
-- max 50 FriendBottle sends per day;
-- server-enforced, not client-only.
+- 10 FriendBottle sends/hour;
+- 50/day.
 
 ---
 
-## 8. DriftBottle for unknown users
+## 9. DriftBottle for unknown users
 
 ### Purpose
 
-Create the feeling that a letter drifted from another quiet boat, not that the player entered random chat.
+Feel like a letter drifted from another quiet boat, not like entering a random chat room.
 
-### Eligibility
+### Additional eligibility
 
-MVP safety profile:
+In addition to 16+ social eligibility:
 
-- Terms/Community Guidelines accepted;
-- self-declared age **16+** for stranger matching;
+- Terms + Community Guidelines accepted;
 - account at least 10 minutes old;
 - at least one completed 5-minute voyage;
-- not currently rate-limited or restricted;
-- client may be anonymous-authenticated, but server identity is still a unique authenticated user id.
+- not restricted/rate-limited.
 
-Declared users under 16 do not receive/send `DriftBottle`; they may use local systems and, where account policy allows, `FriendBottle` only.
+### Acceptance and no-recipient rule
+
+The 5-minute delivery target begins only after the server has found an eligible recipient and **accepted** the send.
+
+If no eligible recipient exists at send time:
+
+- server returns `NO_RECIPIENT_AVAILABLE`;
+- no bottle row is accepted as sent;
+- client keeps/restores the letter as a local draft;
+- UI presents a calm retry-later state;
+- no false 5-minute promise is shown.
+
+This avoids silently queueing a stranger bottle for an unbounded time.
 
 ### Stranger identity
 
-The recipient does not receive the sender's durable account identifier or global profile.
+Each correspondence gets a server-generated ephemeral alias such as adjective+nature-noun+number.
 
-Each stranger correspondence gets an ephemeral server-generated pen-name, for example adjective+nature-noun+number. The alias is scoped to that correspondence only.
-
-No search can resolve that alias back to a global account.
+- alias is scoped to one stranger thread;
+- durable account id/global profile is hidden;
+- no alias search exists;
+- external contact exchange is filtered.
 
 ### Matching
 
-Server selects an eligible recipient who:
+Recipient must:
 
-- is not the sender;
-- is not blocked in either direction;
-- has not been recently over-matched with the sender;
-- is eligible for stranger bottles;
-- is within inbox capacity limits.
+- not be sender;
+- not be blocked either direction;
+- be 16+ and stranger-eligible;
+- be within inbox capacity;
+- not have been recently over-matched with the same sender.
 
 ### Limited stranger correspondence
 
-A stranger pairing may exchange at most **3 round trips** (maximum six letters total) before continuation requires a mutual friend opt-in.
+A stranger thread allows **at most 6 letters total**.
 
-At the limit:
+- server stores `message_count`;
+- when `message_count == 6`, thread moves to `friendship_gate`;
+- either user may end silently;
+- either may request `Continue as friends`;
+- only mutual independent consent creates a durable friendship;
+- no external contact data is revealed automatically.
 
-- either side may end silently;
-- either side may request `Continue as friends`;
-- only if both independently accept does the relationship become a durable `Friendship`;
-- no external contact information is revealed automatically.
+Baseline server rate limits:
 
-This intentionally prevents infinite anonymous-chat threads.
-
-Rate limit baseline:
-
-- max 3 new DriftBottle sends per hour;
-- max 10 new DriftBottle sends per day;
-- replies count toward the same stranger-social budget;
-- server-enforced.
+- 3 new/reply DriftBottle sends/hour;
+- 10/day.
 
 ---
 
-## 9. Safety, moderation, and store compliance
+## 10. Safety, moderation, and store compliance
 
-Bottle letters are UGC. Safety is a release requirement, not post-launch cleanup.
+Bottle letters are UGC. Safety is a release requirement.
 
-### Required before public stranger matching
+Required before any public `DriftBottle` enablement:
 
-- Terms of Use / Community Guidelines acceptance before sending UGC;
-- clearly defined prohibited content;
-- server-side pre-publication filtering;
+- Terms/Community Guidelines acceptance;
+- defined prohibited content;
+- pre-publication filtering;
 - report content;
 - report user;
 - block user;
 - immediate local hide after report/block;
 - moderation review queue;
-- developer contact/support path;
-- data retention/deletion policy;
-- age gating described above;
+- developer support/contact path;
+- retention/deletion policy;
+- age gate;
 - abuse/rate limiting;
-- audit receipt for moderation action.
+- moderation audit receipt.
 
-### Content restrictions in MVP
-
-Block or quarantine:
+Block or quarantine in MVP:
 
 - URLs;
 - email addresses;
 - phone numbers;
-- obvious social handles / external contact exchange patterns;
+- obvious social handles/external contact patterns;
 - sexual solicitation;
 - threats;
 - targeted harassment;
@@ -367,118 +372,98 @@ Block or quarantine:
 - exploitation/grooming patterns;
 - spam/repetition patterns.
 
-### Moderation pipeline
+Pipeline:
 
 ```text
 send request
 → authentication + eligibility
 → normalization
-→ length/sticker schema validation
+→ length/sticker validation
 → contact/URL deterministic filter
 → rate limit
 → server-side semantic moderation adapter
 → ALLOW / REJECT / QUARANTINE
-→ only ALLOW enters delivery queue
+→ only ALLOW enters delivery
 ```
 
-The semantic moderation adapter is server-only. Godot never contains a provider secret.
+Provider secrets are server-only.
 
-**Release gate:** `DriftBottle` remains server-feature-flag OFF unless a production moderation adapter, report/block flow, and moderation operation path are all working in the deployed environment.
+**Release gate:** `DriftBottle` remains feature-flag OFF unless production semantic moderation, report/block UX, moderation operations, Terms, and support contact are deployed and tested.
 
-### App-review positioning
+Apple/Google policy implication: the product must remain primarily a rest/boat/decor game with an incidental bottle-letter feature, not a random/anonymous chat product.
 
-The product must remain a rest/boat/decor game with an incidental bottle-letter feature. Do not redesign the home screen or marketing so random stranger communication becomes the app's primary purpose.
+Authoritative references checked during design:
 
-References checked during design:
-
-- Apple App Review Guidelines 1.2 User-Generated Content, including 2026 clarification for random/anonymous chat.
-- Google Play Developer Program UGC policy requiring terms, moderation, in-app report and block.
+- Apple App Review Guidelines 1.2 User-Generated Content and February 2026 clarification for random/anonymous chat.
+- Google Play Developer Program User Generated Content policy requiring terms, ongoing moderation, in-app report and block.
 
 ---
 
-## 10. Backend trade study
+## 11. Backend trade study
 
 ### A. Supabase — SELECTED FOR MVP
 
-Provides in one stack:
+Integrated strengths:
 
 - anonymous Auth;
-- account linking path;
+- account-link path;
 - Postgres relational model;
 - Row Level Security;
-- Edge Functions;
-- enough free-tier capacity for development and small closed testing.
+- Edge Functions.
 
-Current published Free-plan reference at design time:
+Published Free references at design time:
 
-- 500 MB database per project;
+- 500 MB database/project;
 - 50,000 MAU;
 - 500,000 Edge Function invocations;
 - 2 million Realtime messages;
 - Free projects may pause after one week of inactivity.
 
-We **do not need Supabase Realtime for bottle delivery**. Polling is selected because it supports the product fiction and reduces complexity.
+We do **not** use Realtime for delivery. Polling matches the fiction and lowers complexity.
 
-Risk: Free-plan pause means the 5-minute target cannot be treated as a hard uptime SLA on a dormant free project. Public-launch hosting is a separate deployment Gate.
+Risk: a dormant paused Free project means the 5-minute target is not a hard public-production uptime SLA. Hosting tier is re-Gated before public release.
 
-### B. Cloudflare Workers + D1 — STRONG ZERO-COST ALTERNATIVE
+### B. Cloudflare Workers + D1 — STRONG ZERO-COST FALLBACK
 
-Current free reference at design time:
+Published Free references at design time:
 
-- Workers: 100,000 requests/day;
-- D1: 5 million rows read/day;
-- D1: 100,000 rows written/day;
-- 5 GB total free D1 storage;
-- no equivalent inactivity pause, but daily limits fail closed when exhausted.
+- Workers 100,000 requests/day;
+- D1 5 million rows read/day;
+- D1 100,000 rows written/day;
+- D1 5 GB total free storage.
 
-Advantages:
+Strengths: excellent small-service cost profile, no equivalent inactivity pause.
 
-- excellent small-service cost profile;
-- explicit server function layer;
-- good fit for a narrow bottle service.
+Weaknesses: authentication/friend/security model becomes much more custom than Supabase Auth+RLS.
 
-Disadvantages:
+Keep as migration/fallback if Supabase operational cost/pause becomes a release problem.
 
-- no integrated user/friend authentication model comparable to Supabase Auth+RLS;
-- more custom security/account work;
-- increases implementation surface for a solo project.
+### C. Firebase Auth + Firestore — NOT SELECTED
 
-Decision: keep as migration/fallback option if Supabase operational cost or pause behavior becomes a real release problem.
-
-### C. Firebase Auth + Firestore — REJECT FOR CURRENT MVP
-
-Current free Firestore reference:
+Published Free Firestore references:
 
 - 1 GiB storage;
 - 50,000 document reads/day;
 - 20,000 document writes/day;
 - 10 GiB outbound/month;
-- anonymous authentication supported.
+- anonymous Auth supported.
 
-Advantages:
+Strengths: mature mobile auth and anonymous account linking.
 
-- mature mobile auth;
-- straightforward anonymous-to-linked account path.
-
-Disadvantages:
-
-- message/friend/report relations are less natural than Postgres for this design;
-- server-side moderation/routing adds another function/deployment concern;
-- cost behavior is read/write-operation centered and easier to make noisy with polling if queries are poorly structured.
-
-Decision: not selected.
+Weaknesses: this relational friend/thread/report model fits Postgres better; server moderation/routing adds another deployment concern; polling mistakes can create noisy document-read costs.
 
 ---
 
-## 11. Selected backend architecture
+## 12. Selected backend architecture
 
 ```text
 Godot 4.7
 ├─ local voyage / pet / decor / album / fishing / soundscape
 ├─ SocialSession
-│  ├─ anonymous auth bootstrap
-│  ├─ linked-account state
-│  └─ feature eligibility
+│  ├─ local_only
+│  ├─ anonymous_social
+│  ├─ linked_social
+│  └─ eligibility
 └─ BottleClient
    ├─ send_friend_bottle()
    ├─ send_drift_bottle()
@@ -486,7 +471,8 @@ Godot 4.7
    ├─ reply()
    ├─ report()
    ├─ block()
-   └─ request_friendship()
+   ├─ create_friend_invite()
+   └─ friendship_action()
         │
         ▼
 Supabase
@@ -496,11 +482,13 @@ Supabase
 │  ├─ send-bottle
 │  ├─ poll-inbox
 │  ├─ bottle-action
+│  ├─ friend-invite
 │  ├─ friendship-action
 │  └─ moderation/report intake
 └─ tables
    ├─ profiles
    ├─ social_consents
+   ├─ friend_invites
    ├─ friendships
    ├─ bottle_threads
    ├─ bottles
@@ -509,18 +497,18 @@ Supabase
    └─ moderation_actions
 ```
 
-Do not expose direct table write access for sensitive social state when an Edge Function can enforce the full invariant atomically.
+Sensitive social state is mutated through Edge Functions when full invariants must be enforced atomically.
 
 ---
 
-## 12. Data model
+## 13. Data model
 
 ### `profiles`
 
 - `user_id uuid primary key` → auth user;
-- `display_name text` → visible only where policy allows;
+- `display_name text`;
 - `age_bucket enum('under16','16plus')`;
-- `social_status enum('local_only','stranger_eligible','restricted')`;
+- `social_status enum('local_only','anonymous_social','linked_social','restricted')`;
 - `created_at timestamptz`;
 - `linked_identity boolean`.
 
@@ -531,6 +519,17 @@ Do not expose direct table write access for sensitive social state when an Edge 
 - `community_version text`;
 - `accepted_at timestamptz`;
 - primary key `(user_id, terms_version, community_version)`.
+
+### `friend_invites`
+
+- `id uuid`;
+- `owner_id uuid`;
+- `code_hash text unique`;
+- `expires_at timestamptz`;
+- `used_at timestamptz nullable`;
+- `created_at timestamptz`.
+
+Raw invite codes are returned once to the owner and are not stored in plaintext.
 
 ### `friendships`
 
@@ -548,7 +547,7 @@ Do not expose direct table write access for sensitive social state when an Edge 
 - `participant_b uuid`;
 - `stranger_alias_a text nullable`;
 - `stranger_alias_b text nullable`;
-- `round_trip_count int default 0`;
+- `message_count int default 0`;
 - `state enum('open','friendship_gate','closed','blocked')`;
 - timestamps.
 
@@ -561,13 +560,14 @@ Do not expose direct table write access for sensitive social state when an Edge 
 - `body text`;
 - `sticker_id text nullable`;
 - `created_at timestamptz`;
+- `accepted_at timestamptz`;
 - `deliver_at timestamptz`;
 - `delivered_at timestamptz nullable`;
 - `read_at timestamptz nullable`;
 - `moderation_state enum('allow','reject','quarantine')`;
 - `status enum('queued','available','read','deleted','expired')`.
 
-Database constraints must enforce `length <= 400` at the storage boundary as well as the Edge Function.
+Storage layer also enforces body length <= 400.
 
 ### `blocks`
 
@@ -576,7 +576,7 @@ Database constraints must enforce `length <= 400` at the storage boundary as wel
 - timestamp;
 - unique pair.
 
-A block immediately prevents future matching, thread continuation, and friend sends in both delivery checks and routing.
+Block immediately prevents matching, thread continuation, and friend delivery.
 
 ### `reports`
 
@@ -584,7 +584,7 @@ A block immediately prevents future matching, thread continuation, and friend se
 - reported user;
 - bottle id;
 - reason enum;
-- freeform detail optional and length-limited;
+- optional length-limited detail;
 - status;
 - created timestamp.
 
@@ -598,194 +598,165 @@ A block immediately prevents future matching, thread continuation, and friend se
 
 ---
 
-## 13. RLS and access boundaries
+## 14. RLS and access boundaries
 
-Minimum principles:
-
-- users can read their own profile and only approved public friend-facing fields of accepted friends;
-- users can read bottle content only when they are sender or recipient;
-- client cannot arbitrarily assign `recipient_id` for stranger matching;
-- client cannot set `moderation_state=allow`;
-- client cannot shorten `deliver_at`;
-- client cannot bypass rate limits by writing directly to `bottles`;
-- blocked relationships are checked server-side before every route/send;
-- moderation/report tables are not broadly readable;
-- service-role credentials never ship in Godot.
-
-Use authenticated user JWTs. Anonymous Auth users are still authenticated identities and must be distinguished by claim/account state where social policy requires it.
+- Users read their own profile and only approved friend-facing fields of accepted friends.
+- Users read bottle content only when sender or recipient.
+- Client cannot choose arbitrary `recipient_id` for stranger matching.
+- Client cannot set `moderation_state=allow`.
+- Client cannot shorten `deliver_at`.
+- Client cannot bypass rate limits by direct bottle insert.
+- Blocks are checked server-side before every route/send.
+- Report/moderation tables are not broadly readable.
+- Service-role credentials never ship in Godot.
+- Anonymous Auth is still an authenticated identity and is distinguished by account/social state.
 
 ---
 
-## 14. Offline and failure behavior
+## 15. Offline and failure behavior
 
-### Sending while offline
+### Send while offline
 
-- local draft may be saved;
-- UI says the bottle has **not left the boat yet**;
-- retry only after connectivity returns;
-- do not fabricate a `deliver_at` before server acceptance.
+- save local draft;
+- UI says bottle has not left the boat;
+- retry after connectivity;
+- do not fabricate `deliver_at` before server acceptance.
 
 ### Recipient offline
 
-- bottle becomes available in server inbox at/after `deliver_at`;
-- it remains unread until next successful poll/session;
-- no push notification is required in MVP.
+- bottle becomes available server-side at/after `deliver_at`;
+- remains unread until future poll/session;
+- no push notification required in MVP.
 
 ### Moderation unavailable
 
 - fail closed for `DriftBottle`;
-- FriendBottle may also fail closed until the required production safety policy says otherwise;
-- never silently route an unmoderated stranger message.
+- no unmoderated stranger routing.
 
 ### Backend paused/degraded
 
-- client shows a calm non-urgent state such as "오늘은 바다가 조금 멀리 흐르고 있어요";
-- no streak or reward loss;
-- local voyage/rest loop remains fully playable.
+- calm non-urgent error copy;
+- no streak/reward loss;
+- local voyage/rest/decor remains fully playable.
 
 ---
 
-## 15. Privacy and data minimization
+## 16. Privacy and data minimization
 
-MVP social backend should not require:
+MVP social backend does not require:
 
 - phone contacts;
 - precise location;
-- address book upload;
+- address-book upload;
 - public social graph;
 - real-world name;
 - user photos;
 - voice data.
 
-The bottle subsystem stores only what is necessary for authentication, social eligibility, routing, content moderation, blocking/reporting, and user-requested friendship.
+Store only what is needed for auth, age/social eligibility, routing, moderation, block/report, and requested friendship.
 
-External contact exchange is filtered in stranger correspondence so an ephemeral stranger alias does not become an accidental doxxing channel.
+External contact exchange is filtered in stranger correspondence.
 
 ---
 
-## 16. Integration with the rest loop
+## 17. Rest-loop integration
 
-Bottle social must remain ambient.
+Bottle arrival must stay ambient.
 
-### Arrival presentation
+Preferred presentation:
 
-Do not use a loud push-style popup while the player is resting.
-
-Preferred in-game treatment:
-
-- a bottle quietly appears near the boat / bottle basket;
-- small optional visual indicator;
+- bottle quietly appears near boat/bottle basket;
+- small optional indicator;
 - no countdown;
 - no "reply now" pressure;
-- unread bottles persist until the player chooses to read them.
+- unread bottle persists until chosen.
 
-### Rewards
+Permissible soft rewards: memory entry, decorative postcard frame, album log, optional curated sticker unlock after broad milestones.
 
-Receiving or replying to human bottles must not grant an economy advantage large enough to force social play.
-
-Permissible soft rewards:
-
-- memory entry;
-- decorative postcard frame;
-- album log;
-- optional cosmetic sticker unlock after broad milestones.
-
-Rejected:
-
-- daily reply streak;
-- social currency farming;
-- rarity ranking;
-- response-time bonus;
-- public popularity score.
+Rejected: reply streak, social currency farming, rarity ranking, response-time bonus, public popularity score.
 
 ---
 
-## 17. Implementation decomposition after spec review
+## 18. Implementation decomposition after written-spec review
 
-This architecture is too broad for one implementation PR. It must be split into independently testable slices.
-
-Recommended order:
+This architecture is intentionally split into testable slices rather than one giant PR.
 
 1. **Canon migration + Diorama camera/visible avatar shell**  
    Update AGENTS/Notion/repository direction, preserve Appreciation Camera, add avatar placeholder and camera contract. No backend.
 
 2. **Local decoration + Interactable contract**  
-   Slot zones, local save model, 3–5 representative props, pet/rail/cup interactions. No online dependency.
+   Slot zones, local save model, representative props, pet/rail/cup interactions. No cloud dependency.
 
 3. **Social fake-backend contract**  
-   Godot `BottleClient` interface + deterministic local fake implementing delayed FriendBottle/DriftBottle state transitions, tests for 5-minute target semantics, report/block, thread limits. No real cloud dependency yet.
+   Godot `BottleClient` interface + deterministic local fake implementing delayed FriendBottle/DriftBottle transitions, 5-minute acceptance semantics, report/block, invite-code, age gate, and 6-letter stranger limit.
 
 4. **Supabase schema/Auth/RLS/Edge Functions**  
-   Local Supabase development environment first, migration SQL, tests for unauthorized reads/writes, rate limits, delivery scheduling, block routing, stranger round-trip gate.
+   Local Supabase development first, SQL migrations, anonymous→email-OTP link, RLS/security tests, rate limits, delivery scheduling, block routing, invite flow, stranger gate.
 
-5. **Production moderation + release feature gate**  
-   Server-side moderation adapter, terms acceptance, report queue, block/report UX. Stranger matching remains OFF until this slice passes.
+5. **Production moderation + release gate**  
+   Separate focused design/benchmark for the concrete semantic moderation provider, then implement Terms, report queue, block/report UX and feature gating. `DriftBottle` remains OFF until this passes.
 
 6. **End-to-end delayed bottle integration**  
-   Replace fake backend with real adapter under the same client interface; polling; offline drafts; friend linking; healthy-path delivery timing evidence.
+   Replace fake adapter with real adapter under same client interface; polling; offline drafts; friendship; delivery evidence.
 
 7. **Human/device social-rest validation**  
-   Verify bottle arrival feels ambient, not urgent; verify moderation/report/block discoverability; verify 5-minute target in real network conditions; verify local rest remains functional during backend failure.
+   Verify arrivals feel ambient, safety actions are discoverable, delivery target holds on real networks, and backend failure never blocks rest gameplay.
 
-Each slice gets its own TDD red/green cycle, PR, exact-head CI, adversarial review, and Notion sync.
-
----
-
-## 18. Acceptance criteria for the architecture
-
-The future implementation is only faithful to this design if all are true:
-
-- normal gameplay visibly shows the player avatar and pet in a 3/4 boat diorama;
-- Appreciation Camera still offers a low-UI sea-focused rest view;
-- decoration has no stats or mandatory optimization;
-- object/pet interactions are optional and low-pressure;
-- FriendBottle and DriftBottle are delayed rather than realtime;
-- healthy backend design keeps active-client server receipt under the 5-minute target;
-- stranger communication has no directory, presence, typing, read receipt, or public feed;
-- stranger thread cannot continue indefinitely without mutual friend consent;
-- declared under-16 users cannot use stranger matching in the MVP safety profile;
-- reports and blocks are accessible in-app;
-- blocked users cannot be re-matched or deliver new bottles;
-- UGC moderation happens server-side before stranger delivery;
-- local voyage/rest/decor remains playable if social backend is unavailable;
-- no service-role or moderation-provider secret ships in the Godot client;
-- `DriftBottle` cannot be enabled for public release without the safety release gate.
+Every implementation slice receives its own TDD RED/GREEN, PR, exact-head CI, adversarial review, and Notion sync.
 
 ---
 
-## 19. Explicit non-goals
+## 19. Architecture acceptance criteria
 
-Not part of this design:
+Implementation is faithful only if:
+
+- normal play shows avatar + pet in 3/4 boat diorama;
+- Appreciation Camera still provides low-UI sea rest;
+- decor has no stats/mandatory optimization;
+- interactions remain optional/low-pressure;
+- FriendBottle and DriftBottle are delayed, not realtime;
+- accepted healthy-backend bottles target server availability under 5 minutes;
+- no-recipient DriftBottle is not falsely accepted;
+- all online social is 16+ in MVP;
+- FriendInvite codes are one-time, 8-character, 24-hour and server-generated;
+- stranger mode has no directory, presence, typing, read receipt, or public feed;
+- stranger thread stops at 6 letters unless mutual friendship consent succeeds;
+- report and block are in-app;
+- blocked users cannot re-match or deliver new bottles;
+- stranger UGC is moderated server-side before delivery;
+- local rest/decor/voyage remains playable without backend;
+- no server/moderation secret ships in Godot;
+- `DriftBottle` public feature flag cannot turn on before the safety release gate passes.
+
+---
+
+## 20. Explicit non-goals
 
 - realtime chat;
 - voice/video chat;
 - public timeline/feed;
-- social follower system;
-- location-based matching;
-- dating/matchmaking mechanics;
-- competitive popularity;
-- online co-op movement in the same boat world;
+- follower system;
+- location matching;
+- dating/matchmaking;
+- popularity competition;
+- online co-op movement in the same world;
 - marketplace/trading;
-- user-uploaded images/audio/files in bottle letters;
+- user-uploaded media in letters;
 - unrestricted external contact exchange;
 - backend dependency for basic single-player rest gameplay.
 
 ---
 
-## 20. Design decision summary
+## 21. Decision summary
 
-**Selected product architecture:** `Rest-first Bondee Boat Diorama + Delayed Bottle Social`.
-
-**Selected camera architecture:** 3/4 visible-avatar diorama for normal play + preserved Appreciation Camera for sea-focused rest.
-
-**Selected decoration architecture:** fixed slot zones first.
-
-**Selected interaction architecture:** reusable Interactable contract.
-
-**Selected social model:** delayed FriendBottle + rate-limited/limited-thread DriftBottle; mutual consent required to convert strangers into friends.
-
-**Selected backend for MVP:** Supabase Auth + Postgres/RLS + Edge Functions, with polling instead of Realtime.
-
-**Selected safety posture:** stranger matching is an incidental, gated UGC subsystem and remains disabled until production moderation/report/block/terms operations are deployable.
-
-**Selected cost posture:** develop on free/local-first infrastructure; re-evaluate hosting before public launch if Supabase Free pause/limits conflict with real delivery reliability.
+- Product: **Rest-first Bondee Boat Diorama + Delayed Bottle Social**.
+- Camera: 3/4 visible-avatar normal view + Appreciation Camera.
+- Decoration: fixed slot zones first.
+- Interaction: reusable `Interactable` contract.
+- Social age: all online social 16+ for MVP.
+- Friend discovery: durable linked account + one-time 8-char/24h Friend Invite Code.
+- Stranger social: delayed/rate-limited `DriftBottle`, server-assigned ephemeral alias, max 6 letters, mutual consent to become friends.
+- Delivery: accepted bottles use 45..210 sec intentional delay + 20..30 sec polling, target <=5 min under healthy conditions.
+- MVP backend: Supabase Auth + Postgres/RLS + Edge Functions, polling instead of Realtime.
+- Safety: stranger mode remains OFF until semantic moderation + Terms + report/block + operations are deployed/tested.
+- Cost: local/free-first development; hosting tier is re-Gated before public release if Supabase Free pause/limits conflict with real reliability.

--- a/docs/superpowers/specs/2026-08-24-bondee-diorama-delayed-bottle-design.md
+++ b/docs/superpowers/specs/2026-08-24-bondee-diorama-delayed-bottle-design.md
@@ -1,6 +1,6 @@
 # Rest-first Bondee Boat Diorama + Delayed Bottle Social Design
 
-Status: **USER-APPROVED DESIGN / IMPLEMENTATION GATED BY WRITTEN SPEC REVIEW**  
+Status: **USER-APPROVED DESIGN / READY FOR SLICED IMPLEMENTATION**  
 Date: 2026-08-24  
 Issue: #12  
 Base repository main at design start: `b6949a0b92f591bc099a5cf143b9fe32a863e45f`


### PR DESCRIPTION
Closes #12

## Approved architecture
- visible player avatar + pet in normal play
- 3/4 Bondee-inspired boat diorama + preserved sea-focused Appreciation Camera
- slot-zone boat decoration + reusable low-pressure Interactable contract
- delayed FriendBottle and limited DriftBottle social
- accepted bottle healthy-backend target <= 5 minutes using `deliver_at <= server_now` polling semantics
- no realtime chat/presence/typing/read receipts/public feed
- MVP online social 16+
- one-time 8-char/24h friend invite code; invitee redeems, inviter confirms
- stranger thread max 6 letters, then mutual friend consent or close
- Supabase selected for MVP; Cloudflare Workers+D1 retained as fallback
- DriftBottle public release gated by semantic moderation + Terms + report/block + moderation operations

## Written artifacts
- Spec: `docs/superpowers/specs/2026-08-24-bondee-diorama-delayed-bottle-design.md`
- Slice 1 plan: `docs/superpowers/plans/2026-08-24-canon-migration-diorama-shell.md`

## Review corrections
- all MVP online social made 16+ to remove ambiguous minor handling
- no-recipient DriftBottle is not accepted, so the 5-minute target is never falsely promised
- stranger correspondence uses a hard six-letter cap
- Friend Invite redemption requires inviter confirmation before durable friendship
- MVP delivery requires no cron; poll-inbox resolves `deliver_at <= server_now`
- Slice 1 plan adds an input-isolation RED/GREEN test so inactive Appreciation Camera cannot steal diorama touch input

## Exact verification
- reviewed head: `33956a33471badf4df48800725cc2eda6ef54775`
- Godot 4.7 validation run `32711283557` / run #74: SUCCESS
- 5 clean whole-state review loops after final corrections

## Scope boundary
This PR contains architecture + implementation plan only. Runtime remains unchanged until Slice 1 explicitly migrates `AGENTS.md` and Godot camera/avatar code.