### PR TITLE
Implement deterministic local social fake backend

### DIFF
--- a/.github/workflows/godot-validation.yml
+++ b/.github/workflows/godot-validation.yml
@@ -43,6 +43,7 @@ jobs:
           timeout 20s godot --headless --path . --script res://tests/test_low_pressure_interaction_contract.gd || status=1
           timeout 20s godot --headless --path . --script res://tests/test_boat_life_scene_contract.gd || status=1
           timeout 20s godot --headless --path . --script res://tests/test_boat_life_ui_contract.gd || status=1
+          timeout 20s godot --headless --path . --script res://tests/test_social_fake_backend_contract.gd || status=1
           exit "$status"
 
       - name: Smoke main menu scene

--- a/README.md
+++ b/README.md
@@ -104,6 +104,22 @@ perform(actor_context, action_id)
 - 감상 종료 후 panel 자동 재오픈 없음
 - 자유 3D drag placement는 Human mobile evidence 전까지 defer
 
+### Social Fake Backend Contract
+
+실제 서버·계정·네트워크를 연결하기 전에 approved delayed-bottle product contract만 Godot 내부에서 deterministic하게 재현합니다.
+
+- `scripts/social/social_session_fake.gd`는 `local_only / anonymous_social / linked_social`, 16+ 및 Drift eligibility를 fake state로 재현합니다.
+- `scripts/social/bottle_client_fake.gd`는 순수 `RefCounted` in-memory fake이며 `HTTPRequest`, WebSocket, Supabase, secret을 사용하지 않습니다.
+- accepted bottle은 configurable deterministic delay를 사용하되 승인 범위 `45..210초` 안으로 clamp됩니다.
+- `advance_time()` + `poll_inbox()`로 CI가 실제 시간을 기다리지 않고 `deliver_at` 경계를 검증합니다.
+- recipient가 없는 DriftBottle은 `NO_RECIPIENT_AVAILABLE`이며 accepted/send로 취급하지 않고 local draft를 보존합니다.
+- stranger thread는 6통 이후 `friendship_gate`가 되고 7번째 stranger message는 거부됩니다.
+- 400 Unicode chars는 허용하고 401 chars는 거부하는 기술 계약이 있습니다.
+- fake record에는 typing/presence/read receipt/public feed/follower/ranking 의미를 넣지 않습니다.
+- fake social 호출은 voyage timer, appreciation, affection, album memories, fishing, boat decor를 변경하지 않습니다.
+
+이 Slice는 **실제 소셜 기능 구현이 아닙니다.** Auth/RLS/DB/Edge Function/moderation/report/block/network delivery는 아직 없습니다.
+
 현재 기술 evidence:
 
 ```text
@@ -113,6 +129,7 @@ TECH_RESTING_CORE = PASS
 TECH_BOAT_DECORATION = PASS
 LOW_PRESSURE_INTERACTABLE = PASS
 BOAT_LIFE_TECH_UI = PASS
+SOCIAL_FAKE_BACKEND = PASS
 ```
 
 증거 ceiling:
@@ -123,9 +140,11 @@ REAL_MOBILE_DECOR_QA = NOT_RUN
 FINAL_DECOR_ART = NOT_INTEGRATED
 APP_RESTART_DECOR_PERSISTENCE = NOT_IMPLEMENTED
 PRODUCTION_OCEAN_AUDIO = NOT_INTEGRATED
-FRIEND_BOTTLE = NOT_IMPLEMENTED
-DRIFT_BOTTLE = NOT_IMPLEMENTED
-SOCIAL_BACKEND = NOT_IMPLEMENTED
+HUMAN_SOCIAL_USABILITY = NOT_RUN
+FRIEND_BOTTLE_REAL_NETWORK = NOT_IMPLEMENTED
+DRIFT_BOTTLE_REAL_NETWORK = NOT_IMPLEMENTED
+SUPABASE_AUTH_RLS_EDGE = NOT_IMPLEMENTED
+PRODUCTION_MODERATION_SAFETY = NOT_IMPLEMENTED
 ```
 
 ## 현재 구조
@@ -143,6 +162,8 @@ scripts/
   decor/boat_decor_catalog.gd
   decor/boat_decor_slot.gd
   interaction/low_pressure_interactable.gd
+  social/social_session_fake.gd
+  social/bottle_client_fake.gd
   voyage/boat_rail_interactable.gd
   voyage/boat_camera_controller.gd
   voyage/resting_pet_placeholder.gd
@@ -160,6 +181,7 @@ tests/
   test_low_pressure_interaction_contract.gd
   test_boat_life_scene_contract.gd
   test_boat_life_ui_contract.gd
+  test_social_fake_backend_contract.gd
 ```
 
 ## 자동 검증
@@ -179,18 +201,21 @@ headless project import
 → low-pressure interaction
 → boat life scene
 → boat life UI
+→ social fake backend contract
 → main menu / game / album Scene smoke
 ```
 
-자동 검증은 기술 동작을 증명하지만 실제로 예쁘고 편안하며 모바일에서 쓰기 좋은지는 증명하지 않습니다.
+자동 검증은 기술 동작을 증명하지만 실제로 예쁘고 편안하며 모바일에서 쓰기 좋은지, 실제 소셜이 안전하고 이해 가능한지는 증명하지 않습니다.
 
 ## 다음 구현 순서
 
-1. **Social Fake Backend Contract** — 실제 서버 없이 16+ eligibility, invite, delayed bottle, no-recipient draft, 6-letter cap, block/report semantics를 local fake로 TDD.
-2. **Supabase/Auth/RLS/Edge Functions** — fake contract가 안정된 뒤 adapter 구현.
-3. **Moderation/Safety release gate** — DriftBottle public enable 전 실제 검증.
+1. **Real backend implementation readiness** — current fake interface를 기준으로 실제 provider adapter가 필요한 최소 API/schema/RLS/Edge Function/secret boundary를 구현계획으로 확정합니다.
+2. **Supabase/Auth/RLS/Edge Functions** — 보안·계정 권한 Gate 후 실제 adapter 구현.
+3. **Moderation/Safety release gate** — DriftBottle public enable 전 실제 Terms/age/report/block/moderation 운영 검증.
 4. **Real Delayed Bottle integration**.
 5. Production audio/visual/pet/decor art와 Human/mobile validation.
+
+실제 Supabase project 생성, 계정 연결, secret/API key 취급, public social enable은 이 README의 기술 fake PASS만으로 자동 승인하지 않습니다.
 
 ## Human 검증 — 아직 NOT_RUN
 
@@ -200,6 +225,7 @@ headless project import
 - 자유 3D drag placement가 실제로 필요한가.
 - 상호작용이 `CHORES`나 reward farming이 아닌 작은 생활감으로 느껴지는가.
 - Appreciation Camera와 새 panel이 실제 touch에서 충돌하지 않는가.
+- 병편지의 delayed/no-recipient/6통 제한이 실제 UI에서 자연스럽고 이해 가능한가.
 - 첫 30초/5분이 `CALM`인가 `EMPTY`인가.
 
 ## 계속 금지하는 것

--- a/docs/superpowers/plans/2026-08-24-social-fake-backend.md
+++ b/docs/superpowers/plans/2026-08-24-social-fake-backend.md
@@ -1,0 +1,97 @@
+# Social Fake Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a deterministic local-only fake implementation of the approved delayed FriendBottle/DriftBottle contract so timing, polling, no-recipient, and stranger-thread gates can be verified before any real backend or account work.
+
+**Architecture:** Add two focused `RefCounted` scripts under `scripts/social/`: `SocialSessionFake` owns only fake eligibility/identity state; `BottleClientFake` owns an in-memory accepted-bottle queue, deterministic fake clock, recipient availability, and stranger-thread message count. The fake exposes the same product-facing operations intended for the later real client, but uses no `HTTPRequest`, sockets, auth SDK, credentials, or external service. Tests advance fake time explicitly instead of waiting in real time.
+
+**Tech Stack:** Godot 4.7 stable, GDScript, existing SceneTree contract tests, GitHub Actions `Godot 4.7 validation`.
+
+**Spec:** `docs/superpowers/specs/2026-08-24-bondee-diorama-delayed-bottle-design.md`
+
+## Global Constraints
+
+- Core voyage/rest/pet/decor/album/fishing/soundscape remains local-first and independent of social availability.
+- This slice uses no network, HTTP, Supabase, auth, provider secret, account permission, external moderation provider, or push notification.
+- FriendBottle/DriftBottle remains delayed correspondence, not realtime chat.
+- Accepted delivery delay must stay within the approved 45..210 second product range; tests use an explicit deterministic delay value inside that range.
+- DriftBottle without an eligible recipient returns `NO_RECIPIENT_AVAILABLE` and does not create an accepted/sent bottle.
+- `poll_inbox()` exposes only bottles with `deliver_at <= fake_now`.
+- Stranger correspondence allows at most 6 letters total, then moves to `friendship_gate` and rejects another stranger message.
+- Fake records contain no presence, typing, read-receipt, public-feed, follower, ranking, or public-directory semantics.
+- Social fake operations must not mutate `GameState` voyage time, speed, appreciation, affection, album memories, fishing, or boat decoration.
+- Human social usability/understanding remains `NOT_RUN`.
+
+---
+
+### Task 1: Fake session and delayed bottle contract
+
+**Files:**
+- Create: `scripts/social/social_session_fake.gd`
+- Create: `scripts/social/bottle_client_fake.gd`
+- Create: `tests/test_social_fake_backend_contract.gd`
+- Modify: `.github/workflows/godot-validation.yml`
+
+**Interfaces:**
+- `SocialSessionFake.configure(social_status: String, age_bucket: String, terms_accepted: bool, account_age_seconds: float, completed_voyages: int) -> void`
+- `SocialSessionFake.can_use_friend_bottle() -> bool`
+- `SocialSessionFake.can_use_drift_bottle() -> bool`
+- `BottleClientFake.configure(session, deterministic_delay_seconds: float = 90.0) -> void`
+- `BottleClientFake.set_friend_available(value: bool) -> void`
+- `BottleClientFake.set_drift_recipient_available(value: bool) -> void`
+- `BottleClientFake.send_friend_bottle(text: String, sticker_id: String = "") -> Dictionary`
+- `BottleClientFake.send_drift_bottle(text: String, sticker_id: String = "", thread_id: String = "") -> Dictionary`
+- `BottleClientFake.advance_time(seconds: float) -> void`
+- `BottleClientFake.poll_inbox() -> Array[Dictionary]`
+- `BottleClientFake.get_local_drafts() -> Array[Dictionary]`
+- `BottleClientFake.get_thread_state(thread_id: String) -> String`
+
+- [ ] **Step 1: Write semantic RED**
+
+Create `tests/test_social_fake_backend_contract.gd` that first asserts the two scripts exist, then requires:
+
+```gdscript
+var session = SocialSessionFake.new()
+session.configure("linked_social", "16plus", true, 900.0, 1)
+
+var client = BottleClientFake.new()
+client.configure(session, 90.0)
+client.set_friend_available(true)
+client.set_drift_recipient_available(true)
+```
+
+The test must prove:
+- FriendBottle accepted result has `status == "accepted"` and `deliver_at - accepted_at == 90.0`.
+- polling before 90 seconds returns nothing; at 90 seconds returns the accepted bottle once.
+- a 44-second or 211-second configured delay is clamped into approved 45..210 bounds.
+- DriftBottle with no recipient returns `NO_RECIPIENT_AVAILABLE`, accepted count does not increase, and the text remains in local drafts.
+- a valid DriftBottle is delayed exactly like FriendBottle.
+- exactly six messages in one stranger thread are accepted, thread then reports `friendship_gate`, and the seventh is rejected with `STRANGER_THREAD_LIMIT`.
+- under-16/local-only sessions cannot use online fake social.
+- result dictionaries contain none of `typing`, `presence`, `read_receipt`, `followers`, `ranking`, `public_feed`.
+- snapshots of all current `GameState` voyage/reward/memory/decor fields are unchanged by fake social calls.
+
+- [ ] **Step 2: Register and verify RED**
+
+Add the new test to `.github/workflows/godot-validation.yml`, open the current-task PR, and verify the exact-head CI fails because the two fake scripts/operations are missing. Parse/import errors do not count as semantic RED.
+
+- [ ] **Step 3: Implement minimal fake scripts**
+
+`SocialSessionFake` is a pure `RefCounted` value object. FriendBottle requires `linked_social + 16plus`; DriftBottle requires `anonymous_social` or `linked_social`, `16plus`, terms accepted, account age >= 600 seconds, and at least one completed voyage.
+
+`BottleClientFake` is a pure `RefCounted` in-memory service. It stores `fake_now`, accepted-but-not-yet-polled bottles, delivered ids, local drafts, and `thread_id -> message_count`. It clamps deterministic delay to `45.0..210.0`; `poll_inbox()` returns due undelivered bottles and marks them delivered in memory. It does not reference `GameState` or any network class.
+
+Message validation for this fake slice is intentionally minimal: non-empty text, max 400 Unicode characters, optional sticker string. Production moderation/contact filtering stays outside this slice.
+
+- [ ] **Step 4: Verify GREEN and regressions**
+
+Expected: `PASS: social fake backend contract` plus all pre-existing focused contracts and three Scene smokes remain green.
+
+- [ ] **Step 5: Adversarial review and docs sync**
+
+Re-attack clock boundary, duplicate polling, no-recipient acceptance count, seventh stranger message, core-state isolation, fake-vs-production evidence wording, no accidental network API, and maintenance complexity. After the last correction, require five clean whole-state loops. Update README/MVP/Roadmap only if needed to distinguish `SOCIAL_FAKE_BACKEND=PASS` from real social runtime `NOT_IMPLEMENTED`.
+
+- [ ] **Step 6: Exact-head merge and Notion readback**
+
+Verify current-task PR exact head, current main, comments/reviews/threads, CI, merge safely, read back new main, then sync Registry/Home/Core Loop/FriendBottle/DriftBottle/Production Handoff. Keep real Supabase/Auth/RLS/moderation/networking as `NOT_IMPLEMENTED` and Human social UX as `NOT_RUN`.

--- a/scripts/social/bottle_client_fake.gd
+++ b/scripts/social/bottle_client_fake.gd
@@ -1,0 +1,131 @@
+# 네트워크 없이 지연 병편지 수락·전달·오류 흐름을 재현하는 로컬 fake client다.
+extends RefCounted
+
+const MIN_DELAY_SECONDS := 45.0
+const MAX_DELAY_SECONDS := 210.0
+const MAX_MESSAGE_CHARS := 400
+const MAX_STRANGER_MESSAGES := 6
+
+var _session = null
+var _delay_seconds := 90.0
+var _fake_now := 0.0
+var _friend_available := false
+var _drift_recipient_available := false
+var _pending: Array[Dictionary] = []
+var _delivered_ids: Dictionary = {}
+var _local_drafts: Array[Dictionary] = []
+var _thread_message_counts: Dictionary = {}
+var _next_id := 1
+
+
+func configure(session, deterministic_delay_seconds: float = 90.0) -> void:
+	_session = session
+	_delay_seconds = clampf(deterministic_delay_seconds, MIN_DELAY_SECONDS, MAX_DELAY_SECONDS)
+
+
+func set_friend_available(value: bool) -> void:
+	_friend_available = value
+
+
+func set_drift_recipient_available(value: bool) -> void:
+	_drift_recipient_available = value
+
+
+func send_friend_bottle(text: String, sticker_id: String = "") -> Dictionary:
+	if _session == null or not _session.has_method("can_use_friend_bottle") or not bool(_session.call("can_use_friend_bottle")):
+		return _error("SESSION_NOT_ELIGIBLE")
+	var validation := _validate_message(text)
+	if validation != "":
+		return _error(validation)
+	if not _friend_available:
+		return _error("FRIEND_NOT_AVAILABLE")
+	return _accept_bottle("friend", text, sticker_id, "")
+
+
+func send_drift_bottle(text: String, sticker_id: String = "", thread_id: String = "") -> Dictionary:
+	if _session == null or not _session.has_method("can_use_drift_bottle") or not bool(_session.call("can_use_drift_bottle")):
+		return _error("SESSION_NOT_ELIGIBLE")
+	var validation := _validate_message(text)
+	if validation != "":
+		return _error(validation)
+	var resolved_thread_id := thread_id if thread_id != "" else "thread-%d" % _next_id
+	var message_count := int(_thread_message_counts.get(resolved_thread_id, 0))
+	if message_count >= MAX_STRANGER_MESSAGES:
+		return {
+			"status": "STRANGER_THREAD_LIMIT",
+			"thread_id": resolved_thread_id,
+		}
+	if not _drift_recipient_available:
+		_local_drafts.append({
+			"status": "local_draft",
+			"kind": "drift",
+			"text": text,
+			"sticker_id": sticker_id,
+			"thread_id": resolved_thread_id,
+		})
+		return {
+			"status": "NO_RECIPIENT_AVAILABLE",
+			"thread_id": resolved_thread_id,
+		}
+	_thread_message_counts[resolved_thread_id] = message_count + 1
+	return _accept_bottle("drift", text, sticker_id, resolved_thread_id)
+
+
+func advance_time(seconds: float) -> void:
+	_fake_now += maxf(seconds, 0.0)
+
+
+func poll_inbox() -> Array[Dictionary]:
+	var due: Array[Dictionary] = []
+	for bottle in _pending:
+		var bottle_id := str(bottle.get("id", ""))
+		if bottle_id == "" or _delivered_ids.has(bottle_id):
+			continue
+		if float(bottle.get("deliver_at", INF)) <= _fake_now:
+			due.append(bottle.duplicate(true))
+			_delivered_ids[bottle_id] = true
+	return due
+
+
+func get_local_drafts() -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	for draft in _local_drafts:
+		result.append(draft.duplicate(true))
+	return result
+
+
+func get_thread_state(thread_id: String) -> String:
+	return "friendship_gate" if int(_thread_message_counts.get(thread_id, 0)) >= MAX_STRANGER_MESSAGES else "open"
+
+
+func get_fake_now() -> float:
+	return _fake_now
+
+
+func _accept_bottle(kind: String, text: String, sticker_id: String, thread_id: String) -> Dictionary:
+	var bottle := {
+		"id": "fake-bottle-%d" % _next_id,
+		"status": "accepted",
+		"kind": kind,
+		"text": text,
+		"sticker_id": sticker_id,
+		"accepted_at": _fake_now,
+		"deliver_at": _fake_now + _delay_seconds,
+	}
+	if thread_id != "":
+		bottle["thread_id"] = thread_id
+	_next_id += 1
+	_pending.append(bottle)
+	return bottle.duplicate(true)
+
+
+func _validate_message(text: String) -> String:
+	if text.strip_edges() == "":
+		return "EMPTY_MESSAGE"
+	if text.length() > MAX_MESSAGE_CHARS:
+		return "MESSAGE_TOO_LONG"
+	return ""
+
+
+func _error(status: String) -> Dictionary:
+	return {"status": status}

--- a/scripts/social/social_session_fake.gd
+++ b/scripts/social/social_session_fake.gd
@@ -1,0 +1,44 @@
+# 실제 계정 없이 병편지 eligibility 계약만 재현하는 로컬 fake 세션이다.
+extends RefCounted
+
+var _social_status := "local_only"
+var _age_bucket := "unknown"
+var _terms_accepted := false
+var _account_age_seconds := 0.0
+var _completed_voyages := 0
+
+
+func configure(
+	social_status: String,
+	age_bucket: String,
+	terms_accepted: bool,
+	account_age_seconds: float,
+	completed_voyages: int
+) -> void:
+	_social_status = social_status
+	_age_bucket = age_bucket
+	_terms_accepted = terms_accepted
+	_account_age_seconds = maxf(account_age_seconds, 0.0)
+	_completed_voyages = maxi(completed_voyages, 0)
+
+
+func can_use_friend_bottle() -> bool:
+	return (
+		_social_status == "linked_social"
+		and _age_bucket == "16plus"
+		and _terms_accepted
+	)
+
+
+func can_use_drift_bottle() -> bool:
+	return (
+		(_social_status == "anonymous_social" or _social_status == "linked_social")
+		and _age_bucket == "16plus"
+		and _terms_accepted
+		and _account_age_seconds >= 600.0
+		and _completed_voyages >= 1
+	)
+
+
+func get_social_status() -> String:
+	return _social_status

--- a/tests/test_social_fake_backend_contract.gd
+++ b/tests/test_social_fake_backend_contract.gd
@@ -23,6 +23,9 @@ func _run() -> void:
 		_finish()
 		return
 
+	_assert_local_only_source(session_path)
+	_assert_local_only_source(client_path)
+
 	var session_script = load(session_path)
 	var client_script = load(client_path)
 	_expect(session_script != null, "SocialSessionFake must load")
@@ -92,6 +95,14 @@ func _run() -> void:
 	var high_delay: Dictionary = high_delay_client.call("send_friend_bottle", "높은 경계", "")
 	_expect(is_equal_approx(float(high_delay.get("deliver_at", 0.0)) - float(high_delay.get("accepted_at", 0.0)), 210.0), "fake delay must clamp to approved maximum 210 seconds")
 
+	var text_boundary_client = client_script.new()
+	text_boundary_client.call("configure", session, 90.0)
+	text_boundary_client.call("set_friend_available", true)
+	var exactly_400: String = "가".repeat(400)
+	var over_400: String = "가".repeat(401)
+	_expect(str((text_boundary_client.call("send_friend_bottle", exactly_400, "") as Dictionary).get("status", "")) == "accepted", "400-character bottle text must remain valid")
+	_expect(str((text_boundary_client.call("send_friend_bottle", over_400, "") as Dictionary).get("status", "")) == "MESSAGE_TOO_LONG", "401-character bottle text must be rejected")
+
 	var no_recipient_client = client_script.new()
 	no_recipient_client.call("configure", session, 90.0)
 	no_recipient_client.call("set_drift_recipient_available", false)
@@ -101,6 +112,17 @@ func _run() -> void:
 	_expect(drafts.size() == 1 and str((drafts[0] as Dictionary).get("text", "")) == "누군가에게 닿기를", "no-recipient DriftBottle must remain as a local draft")
 	no_recipient_client.call("advance_time", 300.0)
 	_expect((no_recipient_client.call("poll_inbox") as Array).is_empty(), "no-recipient draft must never appear as delivered")
+
+	var drift_delay_client = client_script.new()
+	drift_delay_client.call("configure", session, 75.0)
+	drift_delay_client.call("set_drift_recipient_available", true)
+	var drift_delayed: Dictionary = drift_delay_client.call("send_drift_bottle", "천천히 표류하는 편지", "", "thread-delay")
+	_expect(str(drift_delayed.get("status", "")) == "accepted", "eligible DriftBottle must be accepted")
+	_expect(is_equal_approx(float(drift_delayed.get("deliver_at", 0.0)) - float(drift_delayed.get("accepted_at", 0.0)), 75.0), "accepted DriftBottle must use the same delayed delivery contract")
+	drift_delay_client.call("advance_time", 74.99)
+	_expect((drift_delay_client.call("poll_inbox") as Array).is_empty(), "DriftBottle must stay hidden before deliver_at")
+	drift_delay_client.call("advance_time", 0.01)
+	_expect((drift_delay_client.call("poll_inbox") as Array).size() == 1, "DriftBottle must become pollable at deliver_at")
 
 	var drift_client = client_script.new()
 	drift_client.call("configure", session, 60.0)
@@ -139,6 +161,16 @@ func _snapshot_core(game_state: Node) -> Dictionary:
 		"voyage_records": game_state.voyage_records.duplicate(),
 		"boat_decor": game_state.boat_decor.duplicate(true),
 	}
+
+
+func _assert_local_only_source(path: String) -> void:
+	var file := FileAccess.open(path, FileAccess.READ)
+	_expect(file != null, "social fake source must be readable: %s" % path)
+	if file == null:
+		return
+	var source := file.get_as_text()
+	for forbidden in ["HTTPRequest", "HTTPClient", "WebSocketPeer", "WebSocketMultiplayerPeer", "supabase", "SUPABASE", "service_role", "api_key"]:
+		_expect(source.find(forbidden) == -1, "social fake must not include real network/backend surface: %s" % forbidden)
 
 
 func _assert_no_realtime_fields(value: Variant) -> void:

--- a/tests/test_social_fake_backend_contract.gd
+++ b/tests/test_social_fake_backend_contract.gd
@@ -1,0 +1,166 @@
+# 지연 병편지 로컬 fake backend의 시간·수락·오류·6통 Gate 계약을 검증한다.
+extends SceneTree
+
+var _failures := 0
+
+
+func _init() -> void:
+	call_deferred("_run")
+
+
+func _run() -> void:
+	var game_state := root.get_node_or_null("GameState")
+	_expect(game_state != null, "GameState autoload must exist")
+	if game_state == null:
+		_finish()
+		return
+
+	var session_path := "res://scripts/social/social_session_fake.gd"
+	var client_path := "res://scripts/social/bottle_client_fake.gd"
+	_expect(ResourceLoader.exists(session_path), "SocialSessionFake script must exist")
+	_expect(ResourceLoader.exists(client_path), "BottleClientFake script must exist")
+	if not ResourceLoader.exists(session_path) or not ResourceLoader.exists(client_path):
+		_finish()
+		return
+
+	var session_script = load(session_path)
+	var client_script = load(client_path)
+	_expect(session_script != null, "SocialSessionFake must load")
+	_expect(client_script != null, "BottleClientFake must load")
+	if session_script == null or client_script == null:
+		_finish()
+		return
+
+	game_state.reset_session()
+	game_state.voyage_active = true
+	game_state.remaining_seconds = 123.0
+	game_state.speed_index = 1
+	game_state.appreciation_mode = false
+	game_state.boat_decor = {"bow_left": "lantern"}
+
+	var before := _snapshot_core(game_state)
+
+	var session = session_script.new()
+	_expect(session.has_method("configure"), "session must expose configure")
+	_expect(session.has_method("can_use_friend_bottle"), "session must expose FriendBottle eligibility")
+	_expect(session.has_method("can_use_drift_bottle"), "session must expose DriftBottle eligibility")
+	if not session.has_method("configure"):
+		_finish()
+		return
+	session.call("configure", "linked_social", "16plus", true, 900.0, 1)
+	_expect(bool(session.call("can_use_friend_bottle")), "linked 16plus session must be FriendBottle eligible")
+	_expect(bool(session.call("can_use_drift_bottle")), "eligible linked session must be DriftBottle eligible")
+
+	var client = client_script.new()
+	_expect(client.has_method("configure"), "client must expose configure")
+	_expect(client.has_method("send_friend_bottle"), "client must expose FriendBottle send")
+	_expect(client.has_method("send_drift_bottle"), "client must expose DriftBottle send")
+	_expect(client.has_method("advance_time"), "client must expose deterministic fake time advance")
+	_expect(client.has_method("poll_inbox"), "client must expose polling")
+	_expect(client.has_method("get_local_drafts"), "client must expose no-recipient local drafts")
+	_expect(client.has_method("get_thread_state"), "client must expose stranger thread state")
+	if not client.has_method("configure"):
+		_finish()
+		return
+
+	client.call("configure", session, 90.0)
+	client.call("set_friend_available", true)
+	client.call("set_drift_recipient_available", true)
+
+	var friend_result: Dictionary = client.call("send_friend_bottle", "오늘 바다가 잔잔하네요.", "")
+	_expect(str(friend_result.get("status", "")) == "accepted", "eligible FriendBottle must be accepted")
+	_expect(is_equal_approx(float(friend_result.get("deliver_at", -1.0)) - float(friend_result.get("accepted_at", -999.0)), 90.0), "accepted FriendBottle must use deterministic 90 second delay")
+	_assert_no_realtime_fields(friend_result)
+	_expect((client.call("poll_inbox") as Array).is_empty(), "accepted bottle must stay hidden before deliver_at")
+	client.call("advance_time", 89.99)
+	_expect((client.call("poll_inbox") as Array).is_empty(), "polling just before deliver_at must still return nothing")
+	client.call("advance_time", 0.01)
+	var due: Array = client.call("poll_inbox")
+	_expect(due.size() == 1, "polling at deliver_at must return the accepted bottle")
+	if due.size() == 1:
+		_assert_no_realtime_fields(due[0])
+	_expect((client.call("poll_inbox") as Array).is_empty(), "delivered bottle must not be returned twice")
+
+	var low_delay_client = client_script.new()
+	low_delay_client.call("configure", session, 44.0)
+	low_delay_client.call("set_friend_available", true)
+	var low_delay: Dictionary = low_delay_client.call("send_friend_bottle", "낮은 경계", "")
+	_expect(is_equal_approx(float(low_delay.get("deliver_at", 0.0)) - float(low_delay.get("accepted_at", 0.0)), 45.0), "fake delay must clamp to approved minimum 45 seconds")
+	var high_delay_client = client_script.new()
+	high_delay_client.call("configure", session, 211.0)
+	high_delay_client.call("set_friend_available", true)
+	var high_delay: Dictionary = high_delay_client.call("send_friend_bottle", "높은 경계", "")
+	_expect(is_equal_approx(float(high_delay.get("deliver_at", 0.0)) - float(high_delay.get("accepted_at", 0.0)), 210.0), "fake delay must clamp to approved maximum 210 seconds")
+
+	var no_recipient_client = client_script.new()
+	no_recipient_client.call("configure", session, 90.0)
+	no_recipient_client.call("set_drift_recipient_available", false)
+	var no_recipient: Dictionary = no_recipient_client.call("send_drift_bottle", "누군가에게 닿기를", "", "thread-none")
+	_expect(str(no_recipient.get("status", "")) == "NO_RECIPIENT_AVAILABLE", "DriftBottle without eligible recipient must not be accepted")
+	var drafts: Array = no_recipient_client.call("get_local_drafts")
+	_expect(drafts.size() == 1 and str((drafts[0] as Dictionary).get("text", "")) == "누군가에게 닿기를", "no-recipient DriftBottle must remain as a local draft")
+	no_recipient_client.call("advance_time", 300.0)
+	_expect((no_recipient_client.call("poll_inbox") as Array).is_empty(), "no-recipient draft must never appear as delivered")
+
+	var drift_client = client_script.new()
+	drift_client.call("configure", session, 60.0)
+	drift_client.call("set_drift_recipient_available", true)
+	for index in range(6):
+		var result: Dictionary = drift_client.call("send_drift_bottle", "조용한 편지 %d" % (index + 1), "", "thread-six")
+		_expect(str(result.get("status", "")) == "accepted", "stranger thread message %d must be accepted before the six-letter gate" % (index + 1))
+	_expect(str(drift_client.call("get_thread_state", "thread-six")) == "friendship_gate", "six accepted stranger letters must move thread to friendship_gate")
+	var seventh: Dictionary = drift_client.call("send_drift_bottle", "일곱 번째 편지", "", "thread-six")
+	_expect(str(seventh.get("status", "")) == "STRANGER_THREAD_LIMIT", "seventh stranger letter must be rejected")
+
+	var underage_session = session_script.new()
+	underage_session.call("configure", "linked_social", "under16", true, 900.0, 1)
+	_expect(not bool(underage_session.call("can_use_friend_bottle")), "under16 fake session must not use FriendBottle")
+	_expect(not bool(underage_session.call("can_use_drift_bottle")), "under16 fake session must not use DriftBottle")
+	var local_session = session_script.new()
+	local_session.call("configure", "local_only", "16plus", true, 900.0, 1)
+	_expect(not bool(local_session.call("can_use_friend_bottle")), "local_only fake session must not use FriendBottle")
+	_expect(not bool(local_session.call("can_use_drift_bottle")), "local_only fake session must not use DriftBottle")
+
+	var after := _snapshot_core(game_state)
+	_expect(before == after, "local social fake operations must not mutate voyage, rewards, memories, or boat decor")
+	_finish()
+
+
+func _snapshot_core(game_state: Node) -> Dictionary:
+	return {
+		"remaining_seconds": float(game_state.remaining_seconds),
+		"speed_index": int(game_state.speed_index),
+		"appreciation_mode": bool(game_state.appreciation_mode),
+		"companion_affection": int(game_state.companion_affection),
+		"photos": game_state.photos.duplicate(),
+		"sceneries": game_state.sceneries.duplicate(),
+		"letters": game_state.letters.duplicate(),
+		"fish": game_state.fish.duplicate(),
+		"voyage_records": game_state.voyage_records.duplicate(),
+		"boat_decor": game_state.boat_decor.duplicate(true),
+	}
+
+
+func _assert_no_realtime_fields(value: Variant) -> void:
+	if not value is Dictionary:
+		_expect(false, "bottle record must be a Dictionary")
+		return
+	var record := value as Dictionary
+	for forbidden in ["typing", "presence", "read_receipt", "followers", "ranking", "public_feed"]:
+		_expect(not record.has(forbidden), "fake bottle records must not expose realtime/social-pressure field: %s" % forbidden)
+
+
+func _expect(condition: bool, message: String) -> void:
+	if condition:
+		return
+	_failures += 1
+	printerr("FAIL: %s" % message)
+
+
+func _finish() -> void:
+	if _failures == 0:
+		print("PASS: social fake backend contract")
+		quit(0)
+	else:
+		printerr("FAILED: %d social fake backend assertions" % _failures)
+		quit(1)


### PR DESCRIPTION
Closes #18

## Implemented
- deterministic local-only `SocialSessionFake` for `local_only / anonymous_social / linked_social`, 16+ and Drift eligibility
- deterministic local-only `BottleClientFake` with approved 45..210 second delayed-delivery bounds
- explicit fake clock via `advance_time()` and polling via `poll_inbox()`
- `NO_RECIPIENT_AVAILABLE` keeps Drift text as local draft and never accepts/delivers it
- six accepted stranger letters move the fake thread to `friendship_gate`; seventh returns `STRANGER_THREAD_LIMIT`
- 400 Unicode chars accepted / 401 rejected
- fake records contain no typing/presence/read-receipt/public-feed/follower/ranking semantics
- fake source contract rejects HTTP/WebSocket/Supabase/secret surfaces
- core `GameState` voyage/reward/memory/decor snapshot remains unchanged by all fake calls
- README now distinguishes `SOCIAL_FAKE_BACKEND=PASS` from real network/auth/moderation `NOT_IMPLEMENTED`

## Explicitly not included
- HTTP/networking
- Supabase project/configuration, Auth, DB, RLS, Edge Functions
- account linking/email OTP
- provider/API secrets
- production moderation/report/block
- public DriftBottle enablement
- push notifications
- final social UI

## TDD evidence
- semantic RED head `754815b496649c17d3252c5feb6933d77086ae13` / run `32737799218` (#135): all 11 pre-existing focused contracts PASS; new social test failed only because `SocialSessionFake` and `BottleClientFake` did not exist
- minimal GREEN scripts added; run #137 SUCCESS
- adversarial acceptance strengthening added 400/401 boundary, real-network-surface rejection, and explicit Drift delayed-poll coverage
- final exact head `1dc768485ece548c01589d9814851b862ac50e10` / run `32738642644` (#139): SUCCESS

## Final evidence ceiling
- SOCIAL_FAKE_BACKEND: PASS
- DELAY_BOUNDARY_45_210: PASS
- NO_RECIPIENT_DRAFT: PASS
- STRANGER_SIX_LETTER_GATE: PASS
- CORE_GAMESTATE_ISOLATION: PASS
- REAL_FRIEND_BOTTLE_NETWORK: NOT_IMPLEMENTED
- REAL_DRIFT_BOTTLE_NETWORK: NOT_IMPLEMENTED
- SUPABASE_AUTH_RLS_EDGE: NOT_IMPLEMENTED
- PRODUCTION_MODERATION_SAFETY: NOT_IMPLEMENTED
- HUMAN_SOCIAL_USABILITY: NOT_RUN

## Review
After the last correction, five clean whole-state loops covered exact-head CI, spec/security alignment, core-state isolation, scope/maintenance cost, and merge/evidence gates. The pre-existing `2 ObjectDB instances were leaked at exit` headless warning remains and is not treated as warning-free evidence.