### PR TITLE
Document visual closeout and durable handoff

### DIFF
--- a/docs/PROJECT_WORK_REUSE_HANDOFF.json
+++ b/docs/PROJECT_WORK_REUSE_HANDOFF.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": 1,
+  "project": "MY_LITTLE_BOAT",
+  "closed_out_at": "2026-08-25",
+  "baseline_main": "e312f9f764051c8a4b25bd6206174498f5353c8e",
+  "selected_modules": [],
+  "reuse_mode": [
+    "REUSE_EXISTING_PROJECT_CANON",
+    "REUSE_BASE_BCP_2026_032_PREVIEW_FALLBACK_PATTERN",
+    "PROJECT_ONLY_EXTRACT"
+  ],
+  "project_paths_changed": [
+    "docs/handoffs/2026-08-25-handpainted-visual-closeout.md",
+    "docs/learning/2026-08-25-handpainted-visual-and-notion-delivery-lessons.md",
+    "docs/PROJECT_WORK_REUSE_HANDOFF.json"
+  ],
+  "verification_evidence": [
+    "GitHub main readback e312f9f764051c8a4b25bd6206174498f5353c8e",
+    "PR #19 fresh readback OPEN head 1dc768485ece548c01589d9814851b862ac50e10",
+    "Notion Asset Library server readback for approved visual proof 01",
+    "Notion native preview attachment created for approved visual proof 02",
+    "Human Home updated to approved visual proof count 2",
+    "Visual Bible readback includes 새벽/밝음/해질녘/밤 time-of-day canon"
+  ],
+  "evidence_ceiling": {
+    "visual_direction": "APPROVED",
+    "approved_visual_proofs": 2,
+    "notion_server_readback": "PASS",
+    "human_visible_client_render_for_proof_02": "NOT_RUN",
+    "final_runtime_handpainted_slice": "NOT_RUN",
+    "final_avatar_pet_boat_sea_art": "NOT_INTEGRATED",
+    "real_mobile_qa": "NOT_RUN"
+  },
+  "rollback": "Docs-only closeout branch can be reverted as one PR; Notion approval metadata can be corrected without changing runtime. Approved image provenance must not be deleted when preview attachment is replaced.",
+  "project_only_lessons": [
+    "HANDPAINTED_STORYBOOK_3D_DIORAMA specific art canon and four time-of-day palette intent",
+    "exact player silhouette/pet/decor candidates remain My Little Boat-specific"
+  ],
+  "base_promotion_candidates": [
+    {
+      "candidate": "NOTION_INLINE_SVG_RASTER_PREVIEW_FALLBACK",
+      "disposition": "CORROBORATES_EXISTING_BCP_2026_032",
+      "new_bcp_required": false
+    },
+    {
+      "candidate": "BATCH_STUDY_IN_ONE_APPROVED_IMAGE_RESULT",
+      "disposition": "OBSERVATION_ONLY",
+      "new_bcp_required": false,
+      "reason": "single-project evidence; current image approval contract already protects one-result boundary"
+    },
+    {
+      "candidate": "APPROVAL_STATE_CONSUMER_DRIFT_SCAN",
+      "disposition": "ALREADY_COVERED_BY_BASE_POST_CHANGE_READBACK",
+      "new_bcp_required": false
+    }
+  ]
+}

--- a/docs/handoffs/2026-08-25-handpainted-visual-closeout.md
+++ b/docs/handoffs/2026-08-25-handpainted-visual-closeout.md
@@ -1,0 +1,173 @@
+# My Little Boat — Handpainted Visual Closeout Handoff
+
+## Receiver acknowledgement contract
+
+새 채팅/새 작업자는 이 문서를 읽은 뒤 아래 5개를 fresh-read하고 작업을 시작한다.
+
+1. `AGENTS.md`
+2. 현재 `main`
+3. open PR inventory, 특히 PR #19
+4. Notion `마이 리틀 보트 · Home` / `02 · 비주얼 바이블` / `04 · 에셋 라이브러리` / `06 · Production · Handoff`
+5. 최신 Base completed main과 현재 작업에 필요한 owner
+
+첫 응답에서 이 문서의 값만 믿고 구현하지 말고, 위 항목의 현재 readback이 일치하는지 확인한다. 불일치하면 최신 권위가 우선한다.
+
+## Durable resume identity
+
+- project: `MY_LITTLE_BOAT`
+- repository: `alsdmlals4-eng/MylittleBoat`
+- handoff baseline main: `e312f9f764051c8a4b25bd6206174498f5353c8e`
+- current detailed visual canon: `HANDPAINTED_STORYBOOK_3D_DIORAMA`
+- parent visual philosophy: `SOFT_STORYBOOK_3D_DIORAMA`
+- normal presentation: visible avatar + resting pet + personal boat + sea in calm 3/4 diorama
+- alternate view: `Appreciation Camera`
+- current approved background time-of-day set: `새벽 / 밝음 / 해질녘 / 밤`
+- runtime engine baseline: Godot 4.7 stable / GDScript
+
+## Approved visual evidence
+
+### Visual Proof 01
+
+- state: `APPROVED_PRODUCTION_VISUAL_PROOF`
+- generation locator: `3dec443c-e61f-40e9-aaf6-470d35c7fde0`
+- role: overall handpainted storybook 3D style, Normal/Appreciation/material language proof
+- Notion: Asset Library native attachment readback PASS
+- proves: style/emotion/material language accepted by user
+- does not prove: final avatar/pet identity, final UI, runtime geometry/shader, mobile/Human runtime quality
+
+### Visual Proof 02
+
+- state: `APPROVED_PRODUCTION_VISUAL_PROOF_02`
+- generation locator: `d9b1a3a9-ae11-4873-b8b2-69264236b38a`
+- original PNG: `1536x1024`
+- original PNG SHA-256: `b79004f60cb79241dca16c0d4eaf367c9e6a1e9f38aaaae1bc043e275d2d518e`
+- role: player silhouette / pet companion / boat living-space & decor exploration
+- Notion delivery: preview-only Notion-native attachment + original provenance metadata
+- proves: user accepts the exploration board as production visual proof
+- does not canonize: final player gender/age/hair/clothing, final pet species, final decor set, exact palette/UI/shader/runtime geometry
+
+## Visual canon details to preserve
+
+- 3D architecture remains; do not convert the project to full 2D.
+- final frame should read closer to a moving illustrated storybook than glossy CG.
+- silhouette before face.
+- minimal face details at mobile gameplay distance.
+- hair in 2–4 broad painted masses rather than glossy strands.
+- hand-painted albedo, matte-biased materials, broad value grouping, restrained specular.
+- sea/horizon remains more important than character beauty, prop density, or UI decoration.
+- pet is a quiet resting companion, not a chore system or attention-seeking mascot.
+- decor should make the boat feel personal and memory-bearing without turning into inventory optimization.
+- no runtime generative AI.
+
+## Background time-of-day canon
+
+Four approved states:
+
+1. `DAWN / 새벽` — cool teal / pale lavender, restrained first light, very quiet.
+2. `BRIGHT / 밝음` — powder blue + soft aqua, clearest neutral default.
+3. `SUNSET / 해질녘` — muted coral / peach / amber, reflective but not saturated spectacle.
+4. `NIGHT / 밤` — dusty blue / deep teal with small warm lantern/cabin light; avoid pure black/neon contrast.
+
+These are atmosphere layers on the same boat/sea/horizon space, not separate maps. Exact clock behavior, selection/automatic rules, palette values, shader parameters, and sound mix are still undecided.
+
+## Current runtime/product state
+
+Merged technical slices before this handoff:
+
+- Calm Voyage + optional Fishing
+- Resting Core technical prototype
+- visible Avatar + 3/4 Diorama + Appreciation Camera
+- BoatSpace + 8-slot Boat Decoration
+- reusable Low-pressure Interactable
+
+Evidence ceiling remains strict:
+
+- final handpainted runtime slice: `NOT_RUN`
+- final Avatar art: `NOT_INTEGRATED`
+- final Pet art: `NOT_INTEGRATED`
+- final Boat/Sea art: `NOT_INTEGRATED`
+- 30s/5m Human visual comfort: `NOT_RUN`
+- real mobile portrait/input QA: `NOT_RUN`
+- motion/performance human QA: `NOT_RUN`
+- app-restart decor persistence: `NOT_IMPLEMENTED`
+
+## Open PR boundary
+
+PR #19 `Implement deterministic local social fake backend` is a pre-existing independent workstream.
+
+- state at handoff: `OPEN`
+- head: `1dc768485ece548c01589d9814851b862ac50e10`
+- base lineage predates current main
+- final recorded CI: run #139 SUCCESS
+- policy: `READ_ONLY / NO ABSORPTION` unless a future user explicitly authorizes PR #19 work
+
+Do not rebase, merge, close, modify, or absorb PR #19 as part of visual work.
+
+## Next visual work
+
+User prefers image work in groups of three, but project image policy still requires an explicit text brief approval before each generated result. Use one approved result containing up to three clearly separated studies when that satisfies the user’s “3 at a time” preference without bypassing the one-result approval gate.
+
+Next recommended visual batch after fresh-read:
+
+1. time-of-day comparison — `새벽 / 밝음 / 해질녘`
+2. follow-up night + lantern/lived-in lighting study
+3. player silhouette narrowing / pet species narrowing / decor memory-language refinement as decisions become ready
+
+Do not generate final production assets in bulk before the current visual proof is translated into a small Godot production slice and checked at target mobile scale.
+
+## Next production slice
+
+Bounded implementation proof:
+
+- one neutral handpainted test player
+- temporary resting-pet treatment without species canonization
+- existing boat material pass
+- sea/sky treatment
+- one small decor cluster
+- Normal vs Appreciation Camera comparison
+- then add four time-of-day lighting states as a separate bounded layer
+
+Success question is not merely “is it pretty?” It is whether the runtime still looks authored/handpainted at 540x960, preserves sea-first composition, survives bob/idle motion, and is feasible for one developer to repeat.
+
+## Notion durable surfaces
+
+- Human Home: `3c41b237-eb1c-8194-8b8e-d88362cafafa`
+- Visual Bible: `3c11b237-eb1c-81ae-97f3-dc28a0905304`
+- Asset Library: `3c11b237-eb1c-8120-b7db-d48e11756146`
+- Production Handoff: `3c11b237-eb1c-81b0-b281-ec54d67c9552`
+- AI Evidence: `3c61b237-eb1c-812f-a9f5-f5a116a98370`
+
+Human Home should remain readable and free of raw PR/SHA/tool/debug metadata except when it directly helps a human understand project status. Exact evidence belongs in AI/System or Production surfaces.
+
+## Notion image delivery rule learned here
+
+When connector-native local binary upload is unavailable and a low-resolution human-facing preview is sufficient:
+
+`approved raster -> downscale/compress preview -> embed preview as data URI in UTF-8 SVG -> create-attachment(content) -> consume returned file-upload:// -> destination fetch -> Notion-owned prod-files-secure readback`
+
+Always preserve original raster provenance separately and mark the SVG path as preview-only. `SERVER_READBACK_PASS != HUMAN_VISIBLE_CLIENT_PASS` and preview delivery is not high-resolution source delivery.
+
+This pattern already exists in Base BCP-2026-032; My Little Boat is an independent corroborating project case, not a reason to create a duplicate BCP.
+
+## Resume idempotency
+
+If a future chat sees that Visual Proof 01/02 and the four time-of-day canon already exist, do not recreate or re-upload them. Fresh-read the durable surfaces, then continue from the first still-unapproved/NOT_RUN gate.
+
+## Pending decisions
+
+Do not infer these without user approval or runtime evidence:
+
+- final player identity
+- final pet species
+- exact day-cycle behavior (real clock / voyage-selected / player-selected / hybrid)
+- exact palette/shader implementation
+- exact UI treatment
+- final representative Visual GDD hero
+- production audio selection
+- real social backend provider/security rollout
+
+## Receiver ack template
+
+A new chat can start with:
+
+`Handoff readback complete: main=<fresh SHA>, PR19=<fresh state/head>, visual canon=HANDPAINTED_STORYBOOK_3D_DIORAMA, approved proofs=<fresh count>, time-of-day canon=새벽/밝음/해질녘/밤. No stale conflict found / conflicts listed below. I will continue from <first unresolved gate>.`

--- a/docs/learning/2026-08-25-handpainted-visual-and-notion-delivery-lessons.md
+++ b/docs/learning/2026-08-25-handpainted-visual-and-notion-delivery-lessons.md
@@ -1,0 +1,138 @@
+# Incident / Solution / Lesson — Handpainted Visual Production & Notion Delivery
+
+## Scope
+
+Project: `MY_LITTLE_BOAT`
+Date: 2026-08-25
+Baseline main: `e312f9f764051c8a4b25bd6206174498f5353c8e`
+
+## Incident 1 — Generic AI 3D look risk
+
+### Problem
+
+Early cozy 3D visual direction risked reading as a generic generated 3D doll: smooth materials, familiar cute-girl archetype, polished beauty render, realistic-ish pet, and decorative detail competing with the sea.
+
+### Root cause
+
+The visual language was specified mainly by broad mood words (`cozy`, `storybook`, `Bondee-like`) rather than production-facing constraints for silhouette, face density, material response, composition hierarchy, and repeatability.
+
+### Alternatives considered
+
+1. keep matte stylized 3D
+2. move to full 2D handpainted game
+3. keep 3D architecture but adopt handpainted storybook surface/character language
+4. pixel/HD-2D alternatives
+
+### Solution
+
+Selected `HANDPAINTED_STORYBOOK_3D_DIORAMA` as detailed canon while preserving `SOFT_STORYBOOK_3D_DIORAMA` as parent philosophy.
+
+Key constraints:
+
+- 3D camera/boat/decor/interaction architecture remains
+- silhouette before face
+- minimal eyes/mouth at gameplay distance
+- hair as broad painted masses
+- hand-painted albedo and matte response
+- sea/horizon remains the dominant visual priority
+- pet remains a quiet resting companion
+
+Two user-approved visual proofs were produced and preserved as approval evidence without over-canonizing final player/pet identity.
+
+### Verification
+
+- PR #22 merged visual canon docs to main
+- Godot 4.7 validation #142 SUCCESS on exact reviewed head
+- Notion Home / Visual Bible / Asset Library / AI Evidence readback
+- user explicitly approved Visual Proof 01 and Visual Proof 02
+
+### Evidence ceiling
+
+This proves visual direction and proof approval, not final runtime art quality, mobile comfort, animation/motion quality, shader performance, or final character/pet identity.
+
+### Lesson
+
+For AI-assisted game visuals, “make it cozy/stylized” is too weak. The durable anti-generic contract should specify **what must dominate, what must be simplified, what must remain irregular/authored, and what is forbidden from becoming a beauty-render focal point**.
+
+Project-only aspects such as exact boat, palette, pet candidate set, and player clothing remain project canon, not Base rules.
+
+## Incident 2 — Batch preference vs one-result approval gate
+
+### Problem
+
+The user prefers working on images three at a time, while the project/Base visual generation policy requires text brief → explicit approval → exactly one result.
+
+### Solution
+
+Use one generated result containing up to three clearly separated study panels when the studies form one coherent approval question. Do not silently produce three independent generated outputs under one approval.
+
+### Lesson
+
+Batch preference can be satisfied at the **composition level** without weakening the one-result approval/evidence gate. This should be revisited if a future tool natively tracks multiple result approvals independently.
+
+## Incident 3 — Notion local binary upload gap
+
+### Problem
+
+Generated PNG existed locally but current Notion `create-attachment` surface accepted UTF-8 content or public HTTPS source URL, not an arbitrary local binary path.
+
+### Existing solution search
+
+Base BCP-2026-032 already defines `NOTION_INLINE_SVG_RASTER_PREVIEW_FALLBACK` from another project. Therefore no duplicate workflow or new tool was built.
+
+### Solution used
+
+For low-resolution human-facing preview only:
+
+`approved PNG -> downscale/compress derivative -> embed JPEG data URI in SVG -> create-attachment(content=<svg>) -> attach returned file-upload:// -> destination fetch/readback`
+
+Original PNG provenance remained separate:
+
+- Visual Proof 02 original: 1536x1024 PNG
+- SHA-256: `b79004f60cb79241dca16c0d4eaf367c9e6a1e9f38aaaae1bc043e275d2d518e`
+- generation locator: `d9b1a3a9-ae11-4873-b8b2-69264236b38a`
+
+### Evidence ceiling
+
+- Notion server-side attachment/readback: PASS when destination returns Notion-owned file
+- high-resolution original delivery: NOT_PROVEN by preview fallback
+- Android/iOS/browser human-visible rendering: NOT_RUN unless directly observed
+
+### Lesson
+
+Preview transport and source-asset preservation are different responsibilities. A fallback must never overwrite the original provenance or be described as high-resolution delivery.
+
+## Incident 4 — Human Home stale status after visual approval
+
+### Problem
+
+After approving the first production visual proof, Human Home still said all generated candidates were reference-only.
+
+### Solution
+
+Updated only the human-facing status line to distinguish:
+
+- approved production visual proof exists
+- final Visual GDD/runtime asset bundle still not finalized
+
+Raw generation IDs/hashes remain in Asset Library / AI Evidence instead of Home.
+
+### Lesson
+
+Every approval-state change should trigger a small **consumer drift scan**: Human Home summary, domain page, Asset Library, Production Handoff, AI Evidence, repository mirror if product meaning changed.
+
+## Reuse / Base promotion disposition
+
+- `NOTION_INLINE_SVG_RASTER_PREVIEW_FALLBACK`: **REUSED_EXISTING_BASE_CANDIDATE** — corroborates BCP-2026-032; do not create duplicate BCP.
+- batch composition under one-result image gate: `BASE_PROMOTION_CANDIDATE`, but current evidence is one project and does not require an active Base rule change yet.
+- handpainted anti-generic art language: mostly `PROJECT_ONLY`; generic principle may inform visual review guidance but exact style rules must not homogenize other projects.
+- consumer drift scan after approval-state change: generalizable, but existing Base post-change/readback rules already cover the responsibility; no new Skill needed.
+
+## Recurrence guards
+
+1. preserve approved proof metadata separately from final runtime asset status
+2. always fresh-read Home after Asset Library approval changes
+3. keep Notion preview fallback explicitly preview-only
+4. search Base reuse/cases before inventing a new upload bridge
+5. do not let image batch preference bypass explicit approval/result count policy
+6. new chats must fresh-read handoff + current main + open PR inventory before resuming


### PR DESCRIPTION
## Goal
Close out the current handpainted visual-production work with a durable new-chat handoff, project learning receipt, and reuse/Base-promotion disposition.

## Added
- `docs/handoffs/2026-08-25-handpainted-visual-closeout.md`
- `docs/learning/2026-08-25-handpainted-visual-and-notion-delivery-lessons.md`
- `docs/PROJECT_WORK_REUSE_HANDOFF.json`

## Durable state captured
- current detailed visual canon `HANDPAINTED_STORYBOOK_3D_DIORAMA`
- approved visual proofs 01/02 and Proof 02 original provenance
- background time-of-day canon `새벽 / 밝음 / 해질녘 / 밤`
- next bounded runtime visual slice
- PR #19 stays `OPEN / READ_ONLY / NO ABSORPTION`
- Notion preview fallback evidence ceiling and server-readback vs human-visible distinction
- receiver-ack / fresh-read / idempotent resume contract for new chats

## Base promotion disposition
No duplicate BCP. My Little Boat independently corroborates existing Base `BCP-2026-032` (`NOTION_INLINE_SVG_RASTER_PREVIEW_FALLBACK`). Existing Base implementation PR #689 remains a separate read-only workstream from this project closeout.

## Evidence ceiling
Docs/Notion closeout only. No Godot runtime art, final avatar/pet identity, real mobile QA, 30s/5m Human visual comfort, or high-resolution Notion source delivery is claimed.

## Review
Five whole-state reviews covered authority/concurrency, visual/evidence boundaries, Notion attachment proof, handoff resumability/idempotency, and Base reuse/no-duplicate-promotion. No blocking finding remained before PR.