### PR TITLE
Prioritize planning and visual closeout before Godot

### DIFF
--- a/docs/CODEX_GOALS.md
+++ b/docs/CODEX_GOALS.md
@@ -2,15 +2,27 @@
 
 Codex에게 작업을 맡길 때는 **현재 Notion/AGENTS 정본과 실제 런타임 증거를 먼저 확인하고, 한 번에 작은 검증 가능한 Slice**를 구현하도록 요청합니다.
 
-## 현재 실행 진입점
+## 현재 상태 · Codex 구현 일시중지
 
-현재 실제 Godot 제품 구현을 시작할 때는 먼저 다음 stable pointer를 읽습니다.
+현재 프로젝트 작업은 Godot 구현이 아니라 **기획·이미지 Closeout**입니다.
+
+현재 전체 작업 진입점:
+
+`docs/handoffs/CURRENT_PLANNING_VISUAL_WORK.md`
+
+Godot 구현 진입점:
 
 `docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md`
 
-이 파일은 현재 Goal·보호 범위·evidence ceiling·fresh-read source를 압축하는 router입니다. 과거 계획의 예시 Node 이름이나 내부 구현 형태를 그대로 구현하라는 뜻이 아니며, Codex는 current GitHub + Notion + 실제 Godot 구조를 fresh-read한 뒤 승인된 결과를 만족하는 최소 안전 구현법을 선택합니다.
+단, 현재 Godot handoff는 `PAUSED_PENDING_PLANNING_VISUAL_CLOSEOUT`입니다. 플레이어 대표 정체성, 첫 펫 종/휴식 인상, 보트·소품 대표 언어, 4시간대 분위기, 대표 UI 존재감, 최종 Representative Visual GDD가 승인·정본화되기 전에는 Codex 제품 구현을 시작하지 않습니다.
 
-현재 `FIRST_PRODUCTION_VISUAL_SLICE`의 이전 v1 plan/handoff에 있는 `VisualStudy` 같은 정확한 Node 이름·테스트 형태는 **illustrative planning sketch**입니다. binding 항목은 player outcome, 승인/보호 의미, TDD-before-implementation, acceptance/evidence ceiling, PR #19 격리, 이미지 생성 금지입니다.
+이미지 생성/생성형 편집은 Codex가 수행하지 않습니다. Visual이 필요하면 GPT/user visual workflow에서 승인한 뒤 Notion Asset Library를 통해 전달합니다.
+
+## 구현 재개 후 원칙
+
+기획·Visual Closeout이 끝난 뒤 `CURRENT_GODOT_IMPLEMENTATION.md`가 다시 implementation-ready로 전환되면 Codex는 current GitHub + Notion + 실제 Godot 구조를 fresh-read한 뒤 승인된 결과를 만족하는 최소 안전 구현법을 선택합니다.
+
+과거 `FIRST_PRODUCTION_VISUAL_SLICE` v1 plan/handoff의 `VisualStudy` 같은 정확한 Node 이름·테스트 형태는 **illustrative planning sketch**이며 구현 강제가 아닙니다. binding 항목은 player outcome, 승인/보호 의미, TDD-before-implementation, acceptance/evidence ceiling, PR #19 격리, 이미지 생성 금지입니다.
 
 ## 예시 1: 마음 선택 개선
 

--- a/docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
+++ b/docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
@@ -1,170 +1,64 @@
 # Current Godot Product Implementation
 
-> Stable current-work pointer for the next Codex Godot product build. This file is a **router/handoff**, not a second game-design canon.
+> **PAUSED DOWNSTREAM HANDOFF.** The current project work is not Godot implementation. Start with `docs/handoffs/CURRENT_PLANNING_VISUAL_WORK.md`.
 
-## Current task
+## Current state
 
 ```yaml
 project: MY_LITTLE_BOAT
 mode: CODEX_GODOT_PRODUCT_IMPLEMENTATION_HANDOFF
-goal: FIRST_PRODUCTION_VISUAL_SLICE
+status: PAUSED_PENDING_PLANNING_VISUAL_CLOSEOUT
+current_work_router: docs/handoffs/CURRENT_PLANNING_VISUAL_WORK.md
 implementation_baseline: RESOLVE_CURRENT_COMPLETED_MAIN_AT_CODEX_START
-implementation_owner: CODEX_GODOT_PRODUCT_IMPLEMENTATION_OWNER
+implementation_owner_after_unpause: CODEX_GODOT_PRODUCT_IMPLEMENTATION_OWNER
 final_review_owner: GPT_FINAL_IMPLEMENTATION_REVIEW
 concurrent_pr_19: READ_ONLY_NO_ABSORPTION
 image_generation_by_codex: FORBIDDEN
-status: READY_FOR_CODEX_FRESH_READ
 ```
 
-At implementation start, do **not** reuse a historical SHA from a plan or chat. Fresh-read the repository default branch, project Notion, current open PRs, actual Godot product files/tests, and the adopted toolchain.
+The user explicitly chose to **finish planning and image work before the First Production Visual Slice**. Do not create a Godot implementation branch, Scene/Resource/GDScript change, product TDD RED, or runtime art translation while this file is paused.
 
-## Authority and supporting package
+## Unpause gate
 
-Current product intent and visual authority:
-
-- Project `AGENTS.md`.
-- Notion Human Home `3c41b237-eb1c-8194-8b8e-d88362cafafa`.
-- Notion Visual Bible `3c11b237-eb1c-81ae-97f3-dc28a0905304`.
-- Notion Asset Library `3c11b237-eb1c-8120-b7db-d48e11756146`.
-- Notion Production Handoff `3c11b237-eb1c-81b0-b281-ec54d67c9552`.
-- Notion AI Evidence `3c61b237-eb1c-812f-a9f5-f5a116a98370`.
-
-Supporting planning artifacts:
-
-- `docs/superpowers/plans/2026-08-26-first-production-visual-slice.md`.
-- `docs/handoffs/2026-08-26-first-production-visual-slice-codex.md`.
-- `docs/research/2026-08-26-first-production-visual-slice-benchmark-evidence.md`.
-
-### Implementation-method correction
-
-The supporting v1 plan contains concrete examples such as a child named `VisualStudy` and example test/node shapes. Those are **illustrative planning sketches, not binding runtime interfaces or required node names**.
+Codex/Godot work resumes only after the current planning/visual owner records all of the following as approved/synced:
 
 ```text
-BINDING
-= player outcome
-+ approved/protected product semantics
-+ evidence ceiling
-+ TDD-before-implementation requirement
-+ acceptance criteria
-+ no-image/no-PR19/no-scope-growth boundaries
-
-NON_BINDING
-= exact node names
-+ exact scene child hierarchy
-+ exact test implementation
-+ exact mesh primitive choice
-+ exact material numeric values
-+ exact internal file split when a safer existing-project pattern is found
+PLAYER_REPRESENTATIVE_IDENTITY = APPROVED
+FIRST_PET_SPECIES_AND_RESTING_READ = APPROVED
+BOAT_DECOR_REPRESENTATIVE_LANGUAGE = APPROVED
+FOUR_TIME_ATMOSPHERE_DIRECTION = APPROVED
+REPRESENTATIVE_UI_PRESENCE = APPROVED_AT_MEANING_LEVEL
+APPROVED_REPRESENTATIVE_VISUAL_GDD = PRODUCED_AND_APPROVED
+ASSET_LIBRARY_READBACK = PASS
+VISUAL_BIBLE_CURRENT_DECISIONS = SYNCED
+PROJECT_PLAN_CURRENT_NEXT_WORK = SYNCED
 ```
 
-Codex must choose the smallest implementation that fits the **actual current Godot structure**. Do not mechanically create a `VisualStudy` API merely because the earlier plan used that name.
+At that point, fresh-read the completed default branch, Project Notion, actual Godot files/tests, current open PRs, and toolchain before rewriting this handoff as implementation-ready.
 
-If the existing structure supports a cleaner proof with different private nodes/resources/tests, use it and explain the choice in the result packet. Any change that alters Core Loop, major UX meaning, final player/pet identity, Art Direction, target-platform product direction, save/schema, social scope, or project-wide shader/asset-pipeline architecture is a `CHANGE_PROPOSAL` back to GPT/user rather than an autonomous implementation choice.
+## Protected downstream scope
 
-## Player outcome
+When eventually resumed, the First Production Visual Slice still must preserve:
 
-On the real current game scene, produce one bounded visual proof that reads materially closer to the approved `HANDPAINTED_STORYBOOK_3D_DIORAMA` than the current generic primitive/CG prototype while preserving the rest-first sea-focused experience.
-
-At 540×960 portrait, the result must make it possible to evaluate:
-
-```text
-sea/horizon remains primary
-→ neutral player + quiet resting companion read together
-→ current BoatSpace feels more authored/lived-in
-→ a small cluster of existing decor belongs to the same low-noise matte language
-→ Normal and Appreciation cameras still feel like the same world
-```
-
-This is not final-art production.
-
-## Protected product semantics
-
-Do not change:
-
-- rest-first Core Loop, voyage duration/rewards, or mood meaning;
-- Normal vs Appreciation Camera behavior meaning or input isolation;
+- rest-first Core Loop, voyage duration/rewards, and mood meaning;
+- Normal vs Appreciation Camera semantics and input isolation;
 - BoatSpace shared bob ownership;
-- 8 decor slot IDs, six current item IDs, compatibility/state meaning, replace/clear no-loss behavior;
+- 8 decor slot IDs and six current item IDs/compatibility/state meaning;
 - low-pressure interaction reward isolation;
-- `has_care_obligation() == false` pet meaning;
-- local-first voyage/rest/pet/decor/album/fishing/soundscape core;
-- final player identity, final pet species, four-state time behavior, final UI, save/schema, localization meaning, or social/backend scope;
-- PR #19 branch/content.
+- care-obligation-free pet meaning;
+- local-first core;
+- PR #19 as an independent workstream unless explicitly reopened.
 
-No combat, failure, competition, chores, farming pressure, ranking, gacha, ads, payment, realtime/public chat, public feed/followers, or runtime generative AI.
+Exact future Node names, scene hierarchy, test implementation, mesh choice, material values, and internal file split remain Codex implementation choices after fresh-read. Historical v1 examples such as `VisualStudy` are non-binding planning sketches.
 
-## Implementation preference — not a mandate
-
-Preferred first trade-study route remains:
+## Evidence ceiling while paused
 
 ```text
-current real 3D scene
-+ deliberate but small silhouette/material improvement
-+ simple opaque matte-biased Godot material path
-+ current light/environment/decor systems
-```
-
-Why: it is the lowest-cost route that can test composition, authored broad values, motion survival, and solo-developer repeatability before a texture/model pipeline or custom watercolor shader is justified.
-
-If runtime evidence shows this route cannot express the approved direction, return evidence instead of scaling complexity automatically. Valid next proposals include `LIGHTWEIGHT_SHADER_FOLLOWUP`, `GPT_APPROVED_AUTHORED_ASSET_REQUEST`, or `VISUAL_DIRECTION_REOPEN_REQUIRED`.
-
-## TDD and verification contract
-
-TDD is binding; the exact test implementation is not.
-
-1. Fresh-read the current product and choose a **semantic, minimally coupled acceptance seam** for this slice.
-2. Add a focused test/contract that fails on the current baseline for the actual missing production-proof property without asserting subjective beauty or final-art quality.
-3. Run and record that RED before implementing the fix.
-4. Implement the smallest production change.
-5. Run focused GREEN plus all affected existing behavior contracts and scene smokes.
-6. Run canonical exact-head PR CI.
-7. Observe runtime only where Codex actually has runtime/capture access; otherwise report `NOT_RUN`.
-
-A structural test may verify preserved camera/decor/pet/scene contracts and a stable marker/resource chosen by Codex, but must not invent a new public runtime API solely to make the test easy.
-
-## Evidence ceiling
-
-Technical implementation or CI does not prove subjective visual quality.
-
-Until direct evidence exists, keep:
-
-```text
+PLANNING_VISUAL_CLOSEOUT = IN_PROGRESS
+HANDPAINTED_3D_RUNTIME_SLICE = NOT_RUN
+PRODUCT_TDD_RED_GREEN = NOT_RUN
 MOBILE_30S_VISUAL_REVIEW = NOT_RUN
 MOBILE_5M_VISUAL_REVIEW = NOT_RUN
-HUMAN_STYLE_APPROVAL = NOT_RUN
+HUMAN_RUNTIME_STYLE_APPROVAL = NOT_RUN
 REAL_DEVICE_TOUCH_QA = NOT_RUN
-FINAL_AVATAR_ART = NOT_INTEGRATED
-FINAL_PET_ART = NOT_INTEGRATED
-FINAL_DECOR_ART = NOT_INTEGRATED
-FINAL_BOAT_SEA_ART = NOT_INTEGRATED
 ```
-
-The current 540×960 portrait viewport is the **primary visual proof target** because it is the actual runtime profile in `project.godot`. Separately, the r5.4 project contract requires responsive semantic-parity coverage for `pc_standard`, `pc_wide_or_ultrawide`, and `mobile_landscape`; Codex must run the representative technical probes that are feasible in its environment and report any missing profile as `NOT_RUN/PARTIAL`, not erase the requirement. These profiles are delivery/semantic-parity requirements and do not by themselves redefine the final store/release platform set. `ko/en/ja/zh-*` readiness and the required Chinese locale variant declaration remain unresolved project-wide requirements; this visual-only slice must not falsely close them or add untranslated user-facing strings.
-
-## Required result packet
-
-```yaml
-codex_result:
-  project: MY_LITTLE_BOAT
-  baseline_main:
-  implementation_branch:
-  final_head:
-  implementation_approach_and_why:
-  changed_godot_files_and_reasons: []
-  protected_behavior_preserved: []
-  tdd_red_evidence: []
-  tests_passed: []
-  tests_failed: []
-  tests_not_run: []
-  runtime_or_play_evidence: []
-  responsive_probe_dimensions: []
-  approved_notion_visuals_consumed: []
-  visual_requests_waiting: []
-  change_proposals: []
-  remaining_risks: []
-  toolchain_observed:
-  rollback:
-  status: READY_FOR_GPT_REVIEW | BLOCKED | WAITING_GPT_VISUAL
-```
-
-Stop at `READY_FOR_GPT_REVIEW`. GPT owns final review, GitHub/Notion canonical reflection, merge/postmerge readback, and completion-ceiling judgment.

--- a/docs/handoffs/CURRENT_PLANNING_VISUAL_WORK.md
+++ b/docs/handoffs/CURRENT_PLANNING_VISUAL_WORK.md
@@ -1,0 +1,245 @@
+# Current Planning & Visual Work
+
+> Stable current-work pointer for the **pre-implementation planning and visual closeout** of `MY_LITTLE_BOAT`. This file is a router/handoff, not a second game-design canon.
+
+## Current task
+
+```yaml
+project: MY_LITTLE_BOAT
+mode: GPT_PLANNING_VISUAL_CLOSEOUT
+current_goal: COMPLETE_PRE_IMPLEMENTATION_PLANNING_AND_VISUALS
+current_owner: GPT_NONCODING_PLANNING_VISUAL_OWNER
+next_godot_owner: CODEX_AFTER_VISUAL_CLOSEOUT_ONLY
+current_main_at_router_creation: 2ecfaa5fd52f45e90bed2abc978af653486fa5e0
+concurrent_pr_19: READ_ONLY_NO_ABSORPTION
+image_generation_now: NOT_REQUESTED
+status: PLANNING_VISUAL_CLOSEOUT_IN_PROGRESS
+```
+
+The user's current priority is explicit: **finish planning and image work first; do not start the Godot production slice yet.**
+
+At every resume, re-read current `main`, Project Notion, approved Visual records, and current user decisions. Historical implementation-ready packets remain available but are paused until this closeout is complete.
+
+## Why Godot implementation is paused
+
+The visual direction is approved, but the visual planning is not asset-complete:
+
+```text
+VISUAL_STYLE_DIRECTION = APPROVED
+DETAILED_VISUAL_STYLE_CANON = HANDPAINTED_STORYBOOK_3D_DIORAMA
+APPROVED_PRODUCTION_VISUAL_PROOFS = 2
+APPROVED_REPRESENTATIVE_VISUAL_GDD = NOT_YET_PRODUCED
+FINAL_AVATAR_IDENTITY = UNDECIDED
+FINAL_PET_SPECIES = UNDECIDED
+FINAL_REPRESENTATIVE_BOAT_DECOR_LANGUAGE = PARTIALLY_DEFINED
+FINAL_TIME_OF_DAY_VISUAL_SET = NOT_PRODUCED
+FINAL_RUNTIME_ART = NOT_INTEGRATED
+```
+
+Starting Godot art translation before those choices are narrowed would turn placeholder implementation into an accidental design authority and increase rework.
+
+## Authority
+
+Human/product authority:
+
+- Notion Human Home: `3c41b237-eb1c-8194-8b8e-d88362cafafa`
+- Notion Visual Bible: `3c11b237-eb1c-81ae-97f3-dc28a0905304`
+- Notion Asset Library: `3c11b237-eb1c-8120-b7db-d48e11756146`
+- Notion Project Plan: `3c11b237-eb1c-810c-80dd-e57ab44c9b23`
+- Notion Production Handoff: `3c11b237-eb1c-81b0-b281-ec54d67c9552`
+- Notion AI Evidence: `3c61b237-eb1c-812f-a9f5-f5a116a98370`
+
+Repository mirrors/support:
+
+- `docs/superpowers/specs/2026-08-25-handpainted-storybook-3d-diorama-design.md`
+- `docs/research/2026-08-26-first-production-visual-slice-benchmark-evidence.md`
+- `docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md` — **paused downstream handoff**, not the current work entrypoint.
+
+## Product decisions already protected
+
+Do not reopen without new user direction:
+
+- rest-first healing voyage promise;
+- visible player + resting pet + personal boat + sea in normal 3/4 diorama;
+- Appreciation Camera as sea/horizon alternate view;
+- `SOFT_STORYBOOK_3D_DIORAMA` parent philosophy;
+- `HANDPAINTED_STORYBOOK_3D_DIORAMA` detailed visual canon;
+- silhouette-first, restrained-face character language;
+- quiet non-obligation pet role;
+- matte / painted / broad-value boat and environment language;
+- stable horizon and sea-first hierarchy;
+- four atmosphere states: dawn / bright / sunset / night;
+- no paid-asset dependency, no runtime generative AI, no social-workstream absorption.
+
+## Existing Visual evidence to reuse
+
+### Approved Production Visual Proof 01
+
+Use for:
+- total frame mood;
+- Normal + Appreciation composition relationship;
+- matte hand-painted material direction;
+- wide calm sea/horizon;
+- low visual noise and lived-in boat feeling.
+
+Do not treat as final character/pet/UI/runtime geometry.
+
+### Approved Production Visual Proof 02
+
+Use for:
+- three player-silhouette directions;
+- quiet companion species/pose exploration;
+- boat-life/decor cluster language;
+- low-detail face and silhouette-first identity.
+
+Do not treat any depicted player or pet as final canon until an explicit selection is recorded.
+
+## Planning closeout questions
+
+The pre-implementation planning phase is complete only after these are answered at the **design meaning level**:
+
+1. **Player identity anchor**
+   - Which silhouette family becomes the representative default?
+   - What 1 primary and 1 secondary shape anchor make the avatar recognizable at 540×960?
+   - What hair/clothing mass language is representative without fixing unnecessary lore?
+
+2. **Pet identity**
+   - Which one species becomes the first representative companion?
+   - Which resting pose is the default read?
+   - What silhouette keeps the pet supportive rather than mascot-dominant?
+
+3. **Boat memory signature**
+   - Which 3–5 existing decor motifs define “my small place on the sea” in the representative frame?
+   - Which one warm light/accent becomes the emotional anchor?
+   - What clutter ceiling keeps the sea visible?
+
+4. **Atmosphere set**
+   - Dawn / Bright / Sunset / Night must feel like the same place through color/light/water response, not separate maps.
+   - One state may be chosen as the representative marketing/GDD frame, but all four need coherent intent.
+
+5. **UI presence in representative visual**
+   - Define only the amount and hierarchy of UI visible in the representative Visual GDD.
+   - Do not prematurely finalize typography, icon family, or every panel.
+
+6. **Representative Visual GDD**
+   - One final approved image must explain normal 3/4 play, avatar + pet relationship, personal boat/decor, sea-first hierarchy, and the quiet interaction/UI layer.
+   - It is the bridge from planning to product implementation; it is still not proof of runtime quality.
+
+## Minimal Visual closeout sequence
+
+Do **not** make a large concept-art backlog. Reuse Proof 01/02 and close the remaining decisions with at most three new approved image results.
+
+### Image A — Player + Pet Identity Board
+
+Purpose: convert Proof 02 exploration into explicit representative identity decisions.
+
+One board should contain:
+- 3 player identity candidates derived from the already approved silhouette language;
+- 3 quiet pet candidates or a tightened comparison of the Proof-02 species families;
+- same camera/scale assumptions so silhouette comparison is fair;
+- no elaborate UI/background composition competing with the subjects.
+
+Must answer:
+- player candidate A/B/C preference;
+- first pet species preference;
+- default resting pose;
+- which face/hair/clothing details are intentionally **not** canonized.
+
+### Image B — Boat / Sea / Four-Time Atmosphere Board
+
+Purpose: lock the environmental and personal-space language before runtime translation.
+
+One board should contain:
+- one consistent representative boat composition;
+- a small 3–5 item lived-in decor cluster using existing motifs;
+- dawn / bright / sunset / night variants of the **same** scene;
+- stable horizon and sea-first hierarchy;
+- one representative warm living accent such as lantern light.
+
+Must answer:
+- representative time-of-day preference for the final Visual GDD;
+- atmosphere differences without changing map identity;
+- decor density ceiling;
+- boat/sea value hierarchy.
+
+### Image C — Representative Visual GDD
+
+Produce only **after A and B decisions are recorded**.
+
+One representative image should show:
+- selected representative player identity;
+- selected first companion species/resting relationship;
+- personal boat with selected decor language;
+- selected representative time-of-day;
+- sea/horizon dominant composition;
+- restrained, readable representative UI/affordance presence;
+- visual explanation of Normal play and, if the composition supports it, a small Appreciation-view inset rather than a second unrelated key art.
+
+This image becomes:
+
+```text
+APPROVED_REPRESENTATIVE_VISUAL_GDD
+```
+
+only after explicit user visual approval and Notion Asset Library upload/readback.
+
+## Visual generation policy
+
+The user has not yet explicitly requested generation in the current turn. Therefore:
+
+```text
+IMAGE_A = NOT_RUN
+IMAGE_B = NOT_RUN
+IMAGE_C = NOT_RUN
+```
+
+Before each generated result:
+
+1. Write a text brief grounded in current Notion canon.
+2. Verify it does not silently decide unrelated lore/gameplay/UI.
+3. Generate only when the user explicitly requests the image.
+4. Treat one generated result as one evidence item; do not claim unseen alternates.
+5. Record prompt/provenance/approval status in the Asset Library.
+6. If rejected, preserve the rejection reason as design evidence; do not overwrite it as if it never existed.
+
+## Benchmark disposition
+
+Current external benchmark evidence is used as **principle evidence only**:
+
+- **ADAPT — Spirit City: Lofi Sessions:** strong attachment comes from readable avatar identity + customizable personal space + companion presence; reject its productivity/XP pressure for My Little Boat.
+- **ADAPT — Dordogne:** authored painterly surface and restrained shader complexity support the “moving illustrated world” goal; do not copy its watercolor treatment literally.
+- **REFERENCE_ONLY — SEASON: A letter to the future:** proves a distinctive illustrated 3D world can use more custom rendering, but its production context does not justify shader-heavy preproduction here.
+- **REJECT — identifiable trade-dress copying:** no direct reuse of another title’s character proportions, UI composition, palette package, branded decor, or signature scene.
+
+## Exit gate before Codex/Godot resumes
+
+Godot implementation remains paused until all are true:
+
+```text
+PLAYER_REPRESENTATIVE_IDENTITY = APPROVED
+FIRST_PET_SPECIES_AND_RESTING_READ = APPROVED
+BOAT_DECOR_REPRESENTATIVE_LANGUAGE = APPROVED
+FOUR_TIME_ATMOSPHERE_DIRECTION = APPROVED
+REPRESENTATIVE_UI_PRESENCE = APPROVED_AT_MEANING_LEVEL
+APPROVED_REPRESENTATIVE_VISUAL_GDD = PRODUCED_AND_APPROVED
+ASSET_LIBRARY_READBACK = PASS
+VISUAL_BIBLE_CURRENT_DECISIONS = SYNCED
+PROJECT_PLAN_CURRENT_NEXT_WORK = SYNCED
+```
+
+Then update `docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md` from paused to implementation-ready and re-run fresh project/main/Notion readback before any Scene/Resource/GDScript mutation.
+
+## Evidence ceiling while this work is active
+
+```text
+PLANNING_VISUAL_CLOSEOUT = IN_PROGRESS
+IMAGE_A = NOT_RUN
+IMAGE_B = NOT_RUN
+IMAGE_C = NOT_RUN
+APPROVED_REPRESENTATIVE_VISUAL_GDD = NOT_YET_PRODUCED
+HANDPAINTED_3D_RUNTIME_SLICE = NOT_RUN
+MOBILE_30S_VISUAL_REVIEW = NOT_RUN
+MOBILE_5M_VISUAL_REVIEW = NOT_RUN
+HUMAN_RUNTIME_STYLE_APPROVAL = NOT_RUN
+REAL_DEVICE_TOUCH_QA = NOT_RUN
+```

--- a/docs/research/2026-08-26-planning-visual-closeout-benchmark.md
+++ b/docs/research/2026-08-26-planning-visual-closeout-benchmark.md
@@ -1,0 +1,96 @@
+# Planning + Visual Closeout Benchmark Evidence
+
+Observed: 2026-08-26
+
+Purpose: support the decision to finish representative player/pet/boat/environment visual planning before starting the Godot hand-painted runtime slice. These are principle references only; they do not replace My Little Boat's Notion canon or user approval.
+
+## 1. Spirit City: Lofi Sessions — ADAPT
+
+Source:
+- Steam: https://store.steampowered.com/app/2113850/Spirit_City_Lofi_Sessions/
+
+Observed product pattern:
+- the product explicitly combines avatar customization, a customizable personal room, ambient soundscapes, and companion creatures;
+- the personal avatar + personal space + companion triangle is a clear attachment surface;
+- as of the observation date the Steam page shows strong user reception and continued 2026 updates.
+
+Use for My Little Boat:
+
+```text
+ADAPT
+= readable player identity
++ personal-space expression
++ companion presence
+```
+
+Do not import:
+- productivity XP/reward pressure;
+- task/habit optimization loop;
+- creature collection as mandatory progression;
+- room-scale UI/productivity framing.
+
+My Little Boat must preserve `rest-first / doing nothing is valid` rather than turning attachment into a reward treadmill.
+
+## 2. Dordogne — ADAPT
+
+Sources:
+- AUTOMATON interview with art director Cédric Babouche: https://automaton-media.com/en/interviews/20230621-19630/
+- GameDeveloper Q&A: https://www.gamedeveloper.com/design/q-a-hand-painting-the-watercolor-world-of-i-dordogne-i-
+
+Observed production lesson:
+- Babouche describes intentionally mixing traditional watercolor and 3D;
+- the team designed around camera needs and kept the technical method simple enough to preserve authored illustration;
+- he explicitly preferred controlled painted results over spending excessive effort on shader complexity he did not control.
+
+Use for My Little Boat:
+
+```text
+ADAPT
+= authored surface first
++ camera-aware composition
++ keep technical stylization subordinate to art intent
+```
+
+Do not copy Dordogne's literal watercolor projection/camera-mapping production technique. My Little Boat has a persistent 3D boat space and broader camera/runtime interaction needs.
+
+## 3. SEASON: A letter to the future — REFERENCE_ONLY / ADAPT SELECTIVELY
+
+Sources:
+- Official art-direction post: https://www.play-season.com/post/january-2022-the-art-direction-of-season
+- Official level-design interview: https://www.play-season.com/post/level-design-interview-april-2022
+
+Observed production lesson:
+- the team aimed for every frame to retain concept-art/illustrative intent;
+- their art direction emphasizes simplification, silhouette/readability, local color, mood, natural-light inspiration, and balancing illustrative texture with believable lighting;
+- the team used custom rendering because it served their specific production context.
+
+Use for My Little Boat:
+
+```text
+ADAPT
+= simplify rather than add detail
++ preserve silhouette hierarchy
++ use time-of-day as mood/light variation of one believable place
+```
+
+Do not infer that My Little Boat needs SEASON's custom shader stack. That remains a future trade-study only if the bounded Godot approach cannot express the approved visual canon.
+
+## 4. Implication for the next three visual results
+
+The benchmark evidence supports narrowing the remaining visual planning in this order:
+
+1. **Identity** — player silhouette + companion species/resting read.
+2. **Place** — representative boat/decor + one coherent sea space across dawn/bright/sunset/night.
+3. **Integrated frame** — one Representative Visual GDD combining the approved identity and place decisions.
+
+This order reduces rework because the final key frame is produced only after the identity and environment decisions it depends on are approved.
+
+## 5. Anti-copy boundary
+
+Benchmarks provide principles only. Do not copy:
+- exact character proportions or clothing from Spirit City;
+- Dordogne's signature watercolor look or scene composition;
+- SEASON's palette package, shader appearance, landmarks, or UI;
+- any identifiable trade dress, branded decor, or signature key art.
+
+My Little Boat remains `HANDPAINTED_STORYBOOK_3D_DIORAMA` with its own sea-first rest identity.

--- a/docs/visual/2026-08-26-preimplementation-image-briefs.md
+++ b/docs/visual/2026-08-26-preimplementation-image-briefs.md
@@ -1,0 +1,330 @@
+# My Little Boat — Pre-Implementation Image Briefs
+
+Status: `TEXT_BRIEF_READY / IMAGE_GENERATION_NOT_RUN`
+
+These briefs close the remaining visual-planning decisions before Godot implementation. They reuse the approved `HANDPAINTED_STORYBOOK_3D_DIORAMA` canon and Approved Production Visual Proof 01/02. They do **not** reopen the art direction.
+
+## Shared visual contract
+
+Every result must preserve:
+
+```text
+3D structure
++ hand-painted storybook surface language
++ stable calm horizon
++ sea-first composition
++ visible player + quiet companion + personal boat
++ matte / low-gloss / broad-value treatment
++ low visual noise
++ mobile portrait readability
+```
+
+Never promote generated text, incidental props, exact UI, or accidental anatomy into canon automatically.
+
+Avoid:
+- glossy generic AI-rendered 3D;
+- beauty-render face as the focal point;
+- huge anime/glass eyes;
+- high-frequency hair strands/fur;
+- mascot-dominant pet posing;
+- busy collectible/inventory framing;
+- photoreal water/wood;
+- dramatic combat/cinematic lighting;
+- paper/parchment UI everywhere;
+- identifiable copying of another game's character, palette, UI, room, or trade dress.
+
+Image generation remains user-controlled. These briefs become generation instructions only when the user explicitly requests the corresponding image.
+
+---
+
+# Image A — Player + Pet Identity Board
+
+## Decision goal
+
+Convert Proof 02's broad player/pet exploration into explicit **representative identity choices** before the final Visual GDD.
+
+This image is a selection board, not key art.
+
+## Canvas / layout
+
+Preferred: landscape style board, approximately 3:2.
+
+Use two calm horizontal sections:
+
+```text
+TOP: three player candidates A / B / C
+BOTTOM: three pet candidates A / B / C + one shared resting-scale comparison
+```
+
+All candidates use the same neutral light, scale, camera angle, and simple off-white/soft-sea background so comparison is fair.
+
+No decorative typography beyond small A/B/C markers if needed; generated labels are not canon.
+
+## Player candidates
+
+All three are neutral representative defaults, not separate story characters.
+
+Shared:
+- compact SD proportions suited to a 540×960 3/4 camera;
+- silhouette readable without facial detail;
+- minimal eyes/mouth, little or no nose at gameplay distance;
+- 2–4 large hair masses;
+- simple large garment masses;
+- calm posture, slightly inward/resting body language;
+- muted colors that do not overpower the sea;
+- no fantasy armor, streetwear logo, luxury fashion, weapon, or overt role/class cue.
+
+Candidate A — **Soft Hooded Layer**
+- rounded hood/outerwear mass as primary silhouette anchor;
+- short-to-medium chunky hair mass;
+- relaxed sleeves and compact lower-body shape;
+- strongest impression: protected, warm, easy to recognize.
+
+Candidate B — **Short Cape / Sailor-Layer Rhythm**
+- simple short capelet/overshirt or layered collar mass without literal uniform cosplay;
+- hair silhouette slightly more open than A;
+- one small secondary scarf/collar shape anchor;
+- strongest impression: sea-linked but still everyday and quiet.
+
+Candidate C — **Loose Knit / Long Hair Mass**
+- soft knit/oversized top mass;
+- longer but still chunky 2–3-part hair silhouette;
+- slightly more vertical/flowing outer silhouette while staying compact;
+- strongest impression: gentle, reflective, less toy-like.
+
+Do not decide:
+- explicit age/lore;
+- final name;
+- exact gender identity;
+- every customization slot;
+- detailed face makeup/accessories.
+
+## Pet candidates
+
+All candidates:
+- small enough to remain a companion, not screen mascot;
+- large simple resting masses;
+- low-detail face;
+- neutral resting pose first;
+- positioned as if they would sit/lie beside the player while both look toward the sea;
+- no care-state icons, collar branding, collectible sparkle, costume, or attention-seeking bounce pose.
+
+Candidate A — **Cat**
+- compact curled/loaf/resting silhouette;
+- minimal upright-ear cue;
+- quiet, familiar, easy to read at mobile distance.
+
+Candidate B — **Rabbit**
+- resting body with ears kept low/back rather than giant mascot ears;
+- calm silhouette and minimal facial detail;
+- avoid hyper-cute chibi proportions.
+
+Candidate C — **Otter-like Companion**
+- low elongated resting body;
+- small round head and compact limbs;
+- subtle aquatic association without turning it into a novelty mascot.
+
+## Acceptance questions
+
+User should be able to answer:
+
+1. Which player candidate has the strongest **My Little Boat** silhouette: A/B/C?
+2. Which pet species best feels like a quiet companion rather than a collectible mascot: cat/rabbit/otter-like?
+3. Which default relationship reads best: side-by-side sea watching / pet curled near player / pet resting slightly behind?
+4. What one detail should be removed because it feels generic-AI, too cute, too fashionable, or too dominant?
+
+## Rejection triggers
+
+Reject/regenerate if:
+- candidate differences are mostly color swaps rather than silhouette choices;
+- faces become the main comparison;
+- pet candidates become mascot merchandising designs;
+- character takes more visual importance than the implied sea/boat context;
+- styles differ so much that comparison is not controlled.
+
+---
+
+# Image B — Boat + Sea + Four-Time Atmosphere Board
+
+## Decision goal
+
+Lock the representative personal-space language and prove that dawn / bright / sunset / night are **the same place with different atmosphere**, not four different maps.
+
+## Canvas / layout
+
+Preferred: landscape 16:9 or wide 2:1 style board.
+
+Use four equal panels of the exact same camera/composition:
+
+```text
+DAWN | BRIGHT | SUNSET | NIGHT
+```
+
+Optional narrow side strip: close material/decor detail only if space remains.
+
+## Fixed scene composition
+
+- same small personal boat, same 3/4 angle;
+- wide calm sea and stable horizon remain major frame masses;
+- no player/pet identity detail needed beyond small neutral silhouettes or omitted figures if they distract from environment comparison;
+- same decor positions in every panel;
+- same weather/no storm.
+
+## Representative decor cluster
+
+Use only 3–5 motifs from the current project language:
+
+Preferred core cluster:
+- lantern — warm living accent / time-of-day anchor;
+- mug — quiet everyday trace;
+- cushion — resting signal;
+- small plant — soft organic life;
+- postcard **or** pet cushion — one memory/relationship trace.
+
+Do not fill all 8 slots. The board must demonstrate the **clutter ceiling**, not catalog density.
+
+## Boat/material language
+
+- chunky simple construction;
+- worn-soft rounded edges;
+- hand-painted warm wood value variation;
+- matte cloth/metal/ceramic;
+- broad brush-like breakup, not photoreal grain;
+- slight controlled hue/value irregularity;
+- readable as one authored set, not separate generated objects.
+
+## Four atmosphere states
+
+### Dawn
+- cool soft blue-violet sea/sky base;
+- restrained peach/cream horizon light;
+- lantern may still be faintly visible;
+- feeling: returning to awareness, quiet beginning.
+
+### Bright
+- clear gentle daylight;
+- low-to-medium contrast;
+- sea remains broad and calm, not tropical neon;
+- minimal artificial light;
+- feeling: rested clarity, breathable openness.
+
+### Sunset
+- warm coral/amber light concentrated around horizon and boat accents;
+- cool sea shadows retained so the frame does not become uniformly orange;
+- lantern begins to matter;
+- feeling: memory, warmth, end-of-day tenderness.
+
+### Night
+- readable deep blue/teal rather than near-black;
+- stable horizon still visible;
+- lantern is the main small warm accent, not a cinematic spotlight;
+- no threatening weather, neon rim light, star-glitter overload, or horror contrast;
+- feeling: safe solitude, not loneliness.
+
+## Acceptance questions
+
+1. Which time state should become the **Representative Visual GDD default frame**?
+2. Do all four clearly read as the same boat/place?
+3. Is the lantern the right warm emotional anchor?
+4. Is 3–5 decor items enough to feel lived-in without pushing the sea backward?
+5. Which panel best balances `CALM` versus `EMPTY`?
+
+## Rejection triggers
+
+Reject/regenerate if:
+- boats/layouts change between time panels;
+- night becomes too dark or dramatic;
+- bright state becomes saturated tropical advertising art;
+- sunset overwhelms the player/boat with orange bloom;
+- decor density becomes an inventory showcase;
+- sea/horizon ceases to be a major content mass.
+
+---
+
+# Image C — Representative Visual GDD
+
+## Dependency gate
+
+Do not generate until Image A and Image B have explicit selected decisions.
+
+Required inputs:
+
+```text
+SELECTED_PLAYER_IDENTITY
+SELECTED_PET_SPECIES
+SELECTED_PET_RESTING_RELATIONSHIP
+SELECTED_REPRESENTATIVE_TIME_STATE
+SELECTED_BOAT_DECOR_CLUSTER
+REPRESENTATIVE_UI_PRESENCE_DECISION
+```
+
+## Decision goal
+
+Produce one human-readable **Visual GDD**, not marketing key art: a single image that explains what normal play should feel like and what the implementation should preserve.
+
+## Composition
+
+Primary large frame:
+- normal 3/4 Boat Diorama;
+- selected player + selected pet resting together;
+- selected 3–5 item boat/decor cluster;
+- selected representative time state;
+- wide sea/horizon clearly visible;
+- quiet UI only where needed to explain normal player affordance hierarchy.
+
+Optional small inset:
+- Appreciation Camera view of the same place, only if it helps explain the normal-vs-appreciation relationship without making the sheet busy.
+
+## Visual reading order
+
+The image must read:
+
+```text
+my small place on the sea
+→ player + pet resting together
+→ soft horizon / water / light
+→ lived-in boat details
+→ optional interaction affordances
+```
+
+It must not read:
+
+```text
+pretty generated character
+→ UI panel
+→ collectible props
+→ sea background
+```
+
+## UI presence
+
+Representative, not final UI design:
+- low-density functional affordances;
+- enough contrast to be readable;
+- world remains visually primary;
+- no ornate parchment/scrapbook treatment;
+- no tiny handwritten font;
+- generated text labels are not canon and can be omitted/abstracted.
+
+## Acceptance questions
+
+The image can be approved as `APPROVED_REPRESENTATIVE_VISUAL_GDD` only if the user can answer yes to:
+
+1. “이 게임을 처음 본 사람이 무엇을 하는 게임인지 대략 느낄 수 있는가?”
+2. “플레이어·펫·보트에 애착이 생기지만 바다가 배경으로 밀리지 않는가?”
+3. “3D인데 움직이는 그림책 같은 방향이 분명한가?”
+4. “아무것도 하지 않고 머무르는 경험이 화면에서 자연스럽게 보이는가?”
+5. “구현자가 이 그림을 보고 무엇을 살려야 하는지 알 수 있는가?”
+
+## Evidence classification
+
+After explicit approval + Notion Asset Library upload/readback:
+
+```text
+APPROVED_REPRESENTATIVE_VISUAL_GDD = APPROVED
+VISUAL_PLANNING_REFERENCE = PASS
+RUNTIME_IMPLEMENTATION = NOT_PROVEN
+HUMAN_RUNTIME_COMFORT = NOT_RUN
+```
+
+The image never upgrades runtime evidence by itself.


### PR DESCRIPTION
## Purpose
Apply the user's latest priority correction: finish planning and image work before resuming the First Production Visual Slice.

## Changes
- add stable current router `docs/handoffs/CURRENT_PLANNING_VISUAL_WORK.md`
- pause `CURRENT_GODOT_IMPLEMENTATION.md` until visual-planning closeout gates are approved
- update `docs/CODEX_GOALS.md` so Codex implementation cannot start early
- add bounded three-image sequence and detailed pre-generation briefs for Image A/B/C
- add fresh benchmark evidence for Spirit City, Dordogne, and SEASON using ADAPT/REFERENCE_ONLY boundaries

## Current visual closeout sequence
1. Image A — player + pet identity board
2. Image B — boat + sea + dawn/bright/sunset/night board
3. Image C — final Representative Visual GDD after A/B selections

## Explicitly not changed
- no Scene/Resource/GDScript/runtime product implementation
- no image generation in this PR/current turn
- no final player/pet selection fabricated without user approval
- no PR #19 mutation/absorption
- no runtime/Human evidence upgrade

## Evidence ceiling
- `PLANNING_VISUAL_CLOSEOUT = IN_PROGRESS`
- `IMAGE_A/B/C = NOT_RUN`
- `APPROVED_REPRESENTATIVE_VISUAL_GDD = NOT_YET_PRODUCED`
- `HANDPAINTED_3D_RUNTIME_SLICE = NOT_RUN`
- Human/mobile validation = `NOT_RUN`

Notion Human Home, Project Plan, Visual Bible, Production Handoff and AI Evidence have been boundedly corrected; System Registry is `REPO_UPDATE_REQUIRED` until this PR is merged and new main is read back.