### PR TITLE
Route image production by real game consumers

### DIFF
--- a/docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
+++ b/docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
@@ -1,14 +1,15 @@
 # Current Godot Product Implementation
 
-> **PAUSED DOWNSTREAM HANDOFF.** The current project work is not Godot implementation. Start with `docs/handoffs/CURRENT_PLANNING_VISUAL_WORK.md`.
+> **PAUSED DOWNSTREAM HANDOFF.** Start with `docs/handoffs/CURRENT_PLANNING_VISUAL_WORK.md`.
 
 ## Current state
 
 ```yaml
 project: MY_LITTLE_BOAT
 mode: CODEX_GODOT_PRODUCT_IMPLEMENTATION_HANDOFF
-status: PAUSED_PENDING_PLANNING_VISUAL_CLOSEOUT
+status: PAUSED_PENDING_CONSUMER_CONTRACTS
 current_work_router: docs/handoffs/CURRENT_PLANNING_VISUAL_WORK.md
+image_asset_policy: CONSUMER_FIRST_ASSET
 implementation_baseline: RESOLVE_CURRENT_COMPLETED_MAIN_AT_CODEX_START
 implementation_owner_after_unpause: CODEX_GODOT_PRODUCT_IMPLEMENTATION_OWNER
 final_review_owner: GPT_FINAL_IMPLEMENTATION_REVIEW
@@ -16,13 +17,9 @@ concurrent_pr_19: READ_ONLY_NO_ABSORPTION
 image_generation_by_codex: FORBIDDEN
 ```
 
-The user explicitly chose to **finish planning and image work before the First Production Visual Slice**. Do not create a Godot implementation branch, Scene/Resource/GDScript change, product TDD RED, or runtime art translation while this file is paused.
+The user corrected the visual pipeline: do not build explanatory image sheets as deliverables. Produce only image files with a concrete game/runtime consumer.
 
-## Approved customization input now waiting downstream
-
-The old assumption of one exclusive representative avatar and one exclusive first pet species is superseded.
-
-When unpaused, implementation planning must preserve these approved feature meanings:
+## Approved customization semantics waiting downstream
 
 ```text
 CHARACTER_SELECTION_SET
@@ -40,59 +37,104 @@ PET_CUSHION_CUSTOMIZATION
 = APPROVED_AT_FEATURE_MEANING_LEVEL
 ```
 
-These are cosmetic/personalization choices, not class/stat/rarity/monetization choices.
+These are cosmetic/personalization choices only. They must not create class/stat/rarity/gacha/monetization/progression differences.
 
-Do not invent a parallel customization inventory by default. When implementation resumes, first evaluate reuse of the existing local-first Boat Decoration/state architecture for cushion customization while keeping character/pet selection semantics appropriately separated.
+## Image-consumer rule
+
+Before an image asset is generated, planning must define:
+
+```text
+asset_path
+consumer
+runtime_role
+spec
+fallback
+validation
+```
+
+An image is not DONE until the intended Godot consumer loads the exact file and runtime evidence shows it in use.
+
+Current main has no production image consumer yet:
+
+```text
+assets/images = README only
+.png references = 0 observed
+albedo_texture references = 0 observed
+Main Menu / Album = ColorRect backgrounds
+Boat / Avatar / Pet = primitive mesh + color-only material
+Decor = primitive mesh + albedo_color
+```
+
+## First candidate consumer batches
+
+### Pet cushion textures
+
+Target meaning:
+- `item_id = pet_cushion`
+- intended material property = `StandardMaterial3D.albedo_texture`
+- runtime role = player-visible pet-cushion appearance customization
+
+### Postcard textures
+
+Target meaning:
+- `item_id = postcard`
+- intended material property = `StandardMaterial3D.albedo_texture`
+- runtime role = authored visible postcard/memory artwork
+
+These are candidates, not yet implemented consumers.
+
+## Deferred image categories
+
+Do not create until the corresponding consumer exists:
+
+- character/pet albedo textures → production mesh + UV required;
+- boat/general decor textures → production mesh + UV required unless a stable primitive consumer is intentionally retained;
+- sky/time-of-day bitmaps → only if Environment adopts panorama/sky textures;
+- sea normal/noise maps → only if the sea material/shader samples them;
+- UI icons → only after TextureButton/TextureRect/theme-icon consumers are approved;
+- main-menu/album backgrounds → current ColorRect means no image asset is needed.
+
+`Image C / Representative Visual GDD` is cancelled as a required production image.
 
 ## Unpause gate
 
-Codex/Godot work resumes only after the current planning/visual owner records all of the following as approved/synced:
+Godot product implementation may resume for a consumer-first asset slice when all are true for at least one asset batch:
 
 ```text
-CHARACTER_SELECTION_SET = APPROVED
-PET_SELECTION_SET = APPROVED
-PET_CUSHION_CUSTOMIZATION = APPROVED_AT_FEATURE_MEANING_LEVEL
-BOAT_DECOR_REPRESENTATIVE_LANGUAGE = APPROVED
-FOUR_TIME_ATMOSPHERE_DIRECTION = APPROVED
-REPRESENTATIVE_UI_PRESENCE = APPROVED_AT_MEANING_LEVEL
-APPROVED_REPRESENTATIVE_VISUAL_GDD = PRODUCED_AND_APPROVED
-ASSET_LIBRARY_READBACK = PASS
-VISUAL_BIBLE_CURRENT_DECISIONS = SYNCED
-PROJECT_PLAN_CURRENT_NEXT_WORK = SYNCED
+ASSET_CONSUMER_CONTRACT = APPROVED
+ASSET_PATH = FIXED
+CONSUMER_TARGET = FIXED
+IMPORT_SPEC = FIXED
+RUNTIME_ROLE = FIXED
+FALLBACK_BEHAVIOR = FIXED
+TDD/VALIDATION_PLAN = READY
+PR_19 = READ_ONLY_NO_ABSORPTION
 ```
 
-At that point, fresh-read the completed default branch, Project Notion, actual Godot files/tests, current open PRs, and toolchain before rewriting this handoff as implementation-ready.
+Then Codex may implement the smallest safe consumer wiring. After the consumer exists and is validated, GPT image generation may produce the exact asset for that consumer, followed by runtime integration verification.
 
 ## Protected downstream scope
-
-When eventually resumed, the First Production Visual Slice still must preserve:
 
 - rest-first Core Loop, voyage duration/rewards, and mood meaning;
 - Normal vs Appreciation Camera semantics and input isolation;
 - BoatSpace shared bob ownership;
 - 8 decor slot IDs and six current item IDs/compatibility/state meaning;
 - low-pressure interaction reward isolation;
-- care-obligation-free pet meaning across every selectable species;
+- care-obligation-free pet semantics across selectable species;
 - cosmetic selection must not alter rewards, timer, progression pressure, social eligibility, or care obligation;
 - local-first core;
-- PR #19 as an independent workstream unless explicitly reopened.
-
-Exact future Node names, scene hierarchy, test implementation, mesh choice, material values, customization UI timing, and internal file split remain Codex implementation choices after fresh-read. Historical v1 examples such as `VisualStudy` are non-binding planning sketches.
+- PR #19 remains an independent workstream unless explicitly reopened.
 
 ## Evidence ceiling while paused
 
 ```text
-PLANNING_VISUAL_CLOSEOUT = IN_PROGRESS
-IMAGE_A_VISUAL_APPROVAL = PASS
-CHARACTER_SELECTION_SET = APPROVED
-PET_SELECTION_SET = APPROVED
-PET_CUSHION_CUSTOMIZATION = APPROVED_AT_FEATURE_MEANING_LEVEL
-IMAGE_B = NOT_RUN
-IMAGE_C = NOT_RUN
-HANDPAINTED_3D_RUNTIME_SLICE = NOT_RUN
+CONSUMER_FIRST_ASSET_POLICY = ACTIVE
+REFERENCE_IMAGES = APPROVED_BUT_NOT_RUNTIME_ASSETS
+CURRENT_RUNTIME_IMAGE_CONSUMERS = 0
+PET_CUSHION_TEXTURES = CONSUMER_CONTRACT_CANDIDATE
+POSTCARD_TEXTURES = CONSUMER_CONTRACT_CANDIDATE
+NEW_GAME_IMAGE_GENERATION = PAUSED
 PRODUCT_TDD_RED_GREEN = NOT_RUN
-MOBILE_30S_VISUAL_REVIEW = NOT_RUN
-MOBILE_5M_VISUAL_REVIEW = NOT_RUN
-HUMAN_RUNTIME_STYLE_APPROVAL = NOT_RUN
+HANDPAINTED_3D_RUNTIME_SLICE = NOT_RUN
 REAL_DEVICE_TOUCH_QA = NOT_RUN
 ```

--- a/docs/handoffs/CURRENT_PLANNING_VISUAL_WORK.md
+++ b/docs/handoffs/CURRENT_PLANNING_VISUAL_WORK.md
@@ -1,264 +1,147 @@
 # Current Planning & Visual Work
 
-> Stable current-work pointer for the **pre-implementation planning and visual closeout** of `MY_LITTLE_BOAT`. This is a router/handoff, not a second game-design canon.
+> Stable current-work router for `MY_LITTLE_BOAT` image production.
 
 ## Current task
 
 ```yaml
 project: MY_LITTLE_BOAT
-mode: GPT_PLANNING_VISUAL_CLOSEOUT
-current_goal: COMPLETE_PRE_IMPLEMENTATION_PLANNING_AND_VISUALS
+mode: GPT_GAME_IMAGE_CONSUMER_PLANNING
+current_goal: DEFINE_REAL_GAME_IMAGE_CONSUMERS_BEFORE_GENERATION
 current_owner: GPT_NONCODING_PLANNING_VISUAL_OWNER
-next_godot_owner: CODEX_AFTER_VISUAL_CLOSEOUT_ONLY
-implementation_baseline: RESOLVE_CURRENT_COMPLETED_MAIN_AT_RESUME
 concurrent_pr_19: READ_ONLY_NO_ABSORPTION
-current_visual_step: IMAGE_B_BOAT_SEA_FOUR_TIME_ATMOSPHERE
-status: PLANNING_VISUAL_CLOSEOUT_IN_PROGRESS
+policy: CONSUMER_FIRST_ASSET
+image_generation: PAUSED_UNTIL_CONSUMER_READY
+status: CONSUMER_MANIFEST_IN_PROGRESS
 ```
 
-The user's priority remains explicit: **finish planning and image work first; do not start the Godot production slice yet.**
+The user explicitly corrected the image-production rule:
 
-At every resume, re-read current `main`, Project Notion, approved Visual records, current open PRs, and latest user decisions. Historical implementation-ready packets remain paused until this closeout is complete.
+> Create images only when they have a real game consumer. Do not create explanatory sheets as deliverables.
 
-## Direct discovery package
+## Authority
 
 Human/product authority:
-
 - Notion Human Home: `3c41b237-eb1c-8194-8b8e-d88362cafafa`
 - Notion Visual Bible: `3c11b237-eb1c-81ae-97f3-dc28a0905304`
 - Notion Asset Library: `3c11b237-eb1c-8120-b7db-d48e11756146`
-- Notion Project Plan: `3c11b237-eb1c-810c-80dd-e57ab44c9b23`
-- Notion Production Handoff: `3c11b237-eb1c-81b0-b281-ec54d67c9552`
-- Notion AI Evidence: `3c61b237-eb1c-812f-a9f5-f5a116a98370`
+- Notion Visual Production Checklist: `3c81b237-eb1c-810c-b3f8-fce023a453cb`
 
-Repository support:
+Repository authority/support:
+- consumer manifest: `docs/visual/2026-08-26-game-image-consumer-manifest.md`
+- approved Image A customization decision: `docs/visual/2026-08-26-image-a-customization-decision.md`
+- paused Godot handoff: `docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md`
 
-- approved style spec: `docs/superpowers/specs/2026-08-25-handpainted-storybook-3d-diorama-design.md`
-- Image A customization decision: `docs/visual/2026-08-26-image-a-customization-decision.md`
-- **current Image B generation brief:** `docs/visual/2026-08-26-image-b-generation-brief.md`
-- historical umbrella A/B/C brief: `docs/visual/2026-08-26-preimplementation-image-briefs.md` — its Image A one-winner questions are superseded by the approved customization decision; do not use them as current gates
-- visual-closeout benchmark evidence: `docs/research/2026-08-26-planning-visual-closeout-benchmark.md`
-- paused downstream Godot handoff: `docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md`
+## Reference images already approved
 
-## Why Godot implementation is still paused
+The following are preserved as planning references, but are **not counted as runtime image assets**:
 
-The art direction and Image A customization set are approved, but the environment/final representative visual decisions are not closed:
+- Visual Proof 01
+- Visual Proof 02
+- Image A — Player + Pet Customization Board
+- Image B — Boat / Sea / Four-Time Atmosphere Board
+
+`Image C / Representative Visual GDD` is cancelled as a required image deliverable.
+
+## Current-main runtime audit
+
+Current main currently has no production image consumer:
 
 ```text
-VISUAL_STYLE_DIRECTION = APPROVED
-DETAILED_VISUAL_STYLE_CANON = HANDPAINTED_STORYBOOK_3D_DIORAMA
-IMAGE_A_VISUAL_APPROVAL = PASS
-CHARACTER_SELECTION_SET = APPROVED
-PET_SELECTION_SET = APPROVED
-PET_CUSHION_CUSTOMIZATION = APPROVED_AT_FEATURE_MEANING_LEVEL
-BOAT_DECOR_REPRESENTATIVE_LANGUAGE = NOT_YET_CLOSED
-FOUR_TIME_ATMOSPHERE_DIRECTION = NOT_YET_CLOSED
-REPRESENTATIVE_UI_PRESENCE = NOT_YET_CLOSED
-APPROVED_REPRESENTATIVE_VISUAL_GDD = NOT_YET_PRODUCED
-FINAL_RUNTIME_ART = NOT_INTEGRATED
+assets/images = README only
+.png references = 0 observed
+albedo_texture references = 0 observed
+Main Menu = ColorRect background
+Album = ColorRect background
+Boat/Avatar/Pet = primitive mesh + color-only StandardMaterial3D
+Decor = primitive mesh + albedo_color construction
 ```
 
-Starting Godot art translation now would still allow environment/UI placeholder choices to become accidental design authority.
-
-## Product decisions already protected
-
-Do not reopen without new user direction:
-
-- rest-first healing voyage promise;
-- visible player + resting pet + personal boat + sea in normal 3/4 diorama;
-- Appreciation Camera as sea/horizon alternate view;
-- `SOFT_STORYBOOK_3D_DIORAMA` parent philosophy;
-- `HANDPAINTED_STORYBOOK_3D_DIORAMA` detailed visual canon;
-- silhouette-first, restrained-face character language;
-- quiet non-obligation pet role;
-- matte / painted / broad-value boat and environment language;
-- stable horizon and sea-first hierarchy;
-- four atmosphere states: dawn / bright / sunset / night;
-- no paid-asset dependency, no runtime generative AI, no social-workstream absorption.
-
-## Approved Image A — customization canon
-
-Image A is approved as a **customization-system visual proof**, not as a one-winner selection board.
-
-### Character selection
-
-All three base style families are selectable:
+Therefore:
 
 ```text
-A = SOFT_HOODED_LAYER
-B = SHORT_CAPE_SAILOR_LAYER_RHYTHM
-C = LOOSE_KNIT_LONG_HAIR_MASS
+CURRENT_RUNTIME_IMAGE_CONSUMERS = 0
 ```
 
-They are visual choices only. They do not create class/stat/rarity/monetization differences.
+Do not generate another gameplay image until a concrete consumer contract is ready.
 
-### Pet selection
+## Consumer-first rule
 
-The first selectable pet set is:
+Every generated game image must have all six before generation:
 
 ```text
-CAT
-RABBIT
-DOG
-OTTER_LIKE
+asset_path
+consumer
+runtime_role
+spec
+fallback
+validation
 ```
 
-All share the same no-obligation resting-companion semantics.
+A generated image is DONE only after the intended Godot consumer actually loads it and it is visible in runtime evidence.
 
-### Pet cushion customization
+## First candidate consumers
 
-`PET_CUSHION_CUSTOMIZATION = APPROVED_AT_FEATURE_MEANING_LEVEL`.
-
-The exact cushion catalog, UI location, persistence mechanics, and number of variants are not yet fixed. Those details must later reuse the existing Boat Decoration architecture where feasible rather than creating a parallel inventory system by default.
-
-### Image A evidence
-
-- user visual approval: `PASS`
-- generation locator: `gen_id 608ba7ff-441b-4c58-b415-94c79a9d7ae6`
-- original observed PNG: `1535×1024`
-- original SHA-256: `5de0a90edad069003be0aa4f2935223ab86883701e51263ca8e3cc36760e7946`
-- Notion Asset Library record: added 2026-08-26
-- Notion-native preview: attached; original local binary itself is represented by provenance metadata because the current connector path cannot directly ingest it.
-
-## Current planning decisions still to close
-
-1. **Boat memory signature**
-   - representative 3–5 existing decor motifs;
-   - one warm living accent;
-   - clutter ceiling that keeps the sea/horizon dominant.
-
-2. **Four-time atmosphere set**
-   - dawn / bright / sunset / night remain the same place through color, light, water, and living-light response;
-   - choose one representative time state for the final Visual GDD after comparison.
-
-3. **Representative UI presence**
-   - lock only how much UI is visible and its hierarchy in the representative frame;
-   - do not prematurely finalize typography, icon family, every panel, or customization flow timing.
-
-4. **Representative Visual GDD**
-   - one final approved image explains normal 3/4 play, customization-capable avatar/pet relationship, personal boat/decor, sea-first hierarchy, and quiet interaction/UI presence;
-   - the depicted character/pet pair is an **example loadout**, not the only playable identity;
-   - it bridges planning to implementation but does not prove runtime quality.
-
-## Current visual sequence
-
-### Image A — Player + Pet Customization Board
+### Pet cushion textures
 
 ```text
-STATUS = APPROVED
+item_id = pet_cushion
+intended consumer = Boat Decoration pet cushion material
+intended property = StandardMaterial3D.albedo_texture
+runtime role = player-visible cushion appearance customization
 ```
 
-Closed decisions:
-- three selectable character style families;
-- four selectable pet species families;
-- pet cushion customization as a feature axis.
+This is the strongest first candidate because the user already approved pet cushion customization and the stable item id already exists.
 
-Do not ask the user to reduce A/B/C or the pet set to one exclusive winner unless the user later changes direction.
-
-### Image B — Boat / Sea / Four-Time Atmosphere Board
+### Postcard textures
 
 ```text
-STATUS = NEXT / TEXT_BRIEF_READY / IMAGE_NOT_RUN
+item_id = postcard
+intended consumer = Boat Decoration postcard material
+intended property = StandardMaterial3D.albedo_texture
+runtime role = authored personal/memory image on placed postcard decor
 ```
 
-**Use `docs/visual/2026-08-26-image-b-generation-brief.md` as the current generation authority.**
+This is also strong because the item id already exists and the visual surface is naturally image-driven.
 
-Use one exact boat/camera/decor composition across four equal variants:
+## Deferred until consumer exists
+
+Do not generate these yet:
+
+- character/pet albedo textures — blocked by production mesh + UV;
+- boat/general decor textures — blocked by production mesh + UV unless current primitives are deliberately retained;
+- sky/time-of-day bitmaps — only if Environment adopts a panorama/sky texture consumer;
+- sea normal/noise maps — only if the sea material/shader actually samples them;
+- UI icons — only after a TextureButton/TextureRect/theme-icon consumer is approved;
+- main-menu/album backgrounds — current screens use ColorRect, so no image is needed now.
+
+## Runtime-generated images
+
+- Album/voyage photos should come from actual runtime capture, not authored concept art.
+- Character/pet selection thumbnails should preferably derive from the real production 3D assets so the thumbnail matches what the player receives.
+
+## Current next work
 
 ```text
-DAWN | BRIGHT | SUNSET | NIGHT
+1. Freeze explanatory-image production.
+2. Complete the game image consumer manifest.
+3. Promote only one small consumer batch to READY_TO_GENERATE.
+4. Recommended first batch: pet cushion textures + postcard textures.
+5. Define exact file path, size, alpha/color-space/import behavior and runtime consumer.
+6. Only then generate those image assets.
+7. Godot product owner wires them and proves exact-file runtime consumption.
 ```
 
-Keep character/pet detail omitted or as small neutral silhouettes so the environment comparison stays controlled.
-
-Image B must answer:
-- whether all four states unmistakably read as the same place;
-- representative time-of-day preference for Image C;
-- 3–5 item decor cluster and clutter ceiling;
-- one warm living-light accent;
-- sea/horizon versus boat/decor value hierarchy;
-- whether any time state becomes too dramatic, high-contrast, or gamey for rest-first use.
-
-Do not change map identity, boat layout, camera, or decor positions between time states merely to make each panel more attractive.
-
-### Image C — Representative Visual GDD
+## Evidence ceiling
 
 ```text
-STATUS = BLOCKED_BY_IMAGE_B
-```
-
-Generate only after Image B decisions are recorded.
-
-Image C must:
-- use one **representative example** from the approved character/pet selection sets, not imply exclusivity;
-- show personal boat/decor language selected from Image B;
-- use the selected representative time state;
-- keep sea/horizon dominant;
-- show restrained representative UI/affordance presence;
-- show Normal play and, only if useful, a small Appreciation-view inset;
-- communicate that avatar/pet/cushion are customizable in supporting planning text without turning the key frame into a catalog screen.
-
-It becomes `APPROVED_REPRESENTATIVE_VISUAL_GDD` only after explicit user visual approval and Notion Asset Library upload/readback.
-
-## Visual generation policy
-
-```text
-IMAGE_A = APPROVED
-IMAGE_B = NOT_RUN
-IMAGE_C = NOT_RUN
-```
-
-Before each new generated result:
-
-1. Use the current text brief and latest user decisions.
-2. Verify it does not silently decide unrelated lore/gameplay/UI.
-3. Treat one generated result as one evidence item; do not claim unseen alternates.
-4. Record generation provenance and approval status in the Asset Library.
-5. Preserve rejection reasons as design evidence.
-
-## Benchmark disposition
-
-Full locators and evidence remain in `docs/research/2026-08-26-planning-visual-closeout-benchmark.md`.
-
-- **ADAPT — Spirit City: Lofi Sessions:** readable avatar identity + personal space + companion presence; reject productivity/XP pressure.
-- **ADAPT — Dordogne:** authored painterly surface + camera-aware composition + restrained technical complexity; do not copy literal watercolor treatment.
-- **REFERENCE_ONLY / ADAPT selectively — SEASON: A letter to the future:** simplification, silhouette/readability, believable time-of-day mood; do not infer that My Little Boat needs its custom shader stack.
-- **REJECT — identifiable trade-dress copying.**
-
-## Exit gate before Codex/Godot resumes
-
-All must be true:
-
-```text
-CHARACTER_SELECTION_SET = APPROVED
-PET_SELECTION_SET = APPROVED
-PET_CUSHION_CUSTOMIZATION = APPROVED_AT_FEATURE_MEANING_LEVEL
-BOAT_DECOR_REPRESENTATIVE_LANGUAGE = APPROVED
-FOUR_TIME_ATMOSPHERE_DIRECTION = APPROVED
-REPRESENTATIVE_UI_PRESENCE = APPROVED_AT_MEANING_LEVEL
-APPROVED_REPRESENTATIVE_VISUAL_GDD = PRODUCED_AND_APPROVED
-ASSET_LIBRARY_READBACK = PASS
-VISUAL_BIBLE_CURRENT_DECISIONS = SYNCED
-PROJECT_PLAN_CURRENT_NEXT_WORK = SYNCED
-```
-
-Then update `docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md` from paused to implementation-ready and fresh-read repository default branch + Project Notion + actual Godot structure before any Scene/Resource/GDScript mutation.
-
-## Evidence ceiling while active
-
-```text
-PLANNING_VISUAL_CLOSEOUT = IN_PROGRESS
-IMAGE_A_VISUAL_APPROVAL = PASS
-CHARACTER_SELECTION_SET = APPROVED
-PET_SELECTION_SET = APPROVED
-PET_CUSHION_CUSTOMIZATION = APPROVED_AT_FEATURE_MEANING_LEVEL
-IMAGE_B_TEXT_BRIEF = READY
-IMAGE_B = NOT_RUN
-IMAGE_C = NOT_RUN
-APPROVED_REPRESENTATIVE_VISUAL_GDD = NOT_YET_PRODUCED
+CONSUMER_FIRST_ASSET_POLICY = ACTIVE
+REFERENCE_IMAGES = APPROVED_BUT_NOT_RUNTIME_ASSETS
+IMAGE_C_REPRESENTATIVE_VISUAL_GDD = CANCELLED
+CURRENT_RUNTIME_IMAGE_CONSUMERS = 0
+PET_CUSHION_TEXTURES = CONSUMER_CONTRACT_CANDIDATE
+POSTCARD_TEXTURES = CONSUMER_CONTRACT_CANDIDATE
+NEW_GAME_IMAGE_GENERATION = PAUSED
 HANDPAINTED_3D_RUNTIME_SLICE = NOT_RUN
-MOBILE_30S_VISUAL_REVIEW = NOT_RUN
-MOBILE_5M_VISUAL_REVIEW = NOT_RUN
-HUMAN_RUNTIME_STYLE_APPROVAL = NOT_RUN
-REAL_DEVICE_TOUCH_QA = NOT_RUN
+REAL_DEVICE_QA = NOT_RUN
 ```


### PR DESCRIPTION
## Purpose
Apply the user's corrected production rule: create only images with a concrete Godot/game consumer, not explanatory sheets.

## Changes
- current planning router now uses `CONSUMER_FIRST_ASSET`
- Godot handoff unpause gate now requires an asset consumer contract rather than a Representative Visual GDD
- cancels Image C / Representative Visual GDD as a required image deliverable
- keeps Image A/B and earlier proofs as approved references only
- routes the first candidate game-consumable image batches to `pet_cushion` textures and `postcard` textures

## Runtime audit
Current main has no production image consumer: `assets/images` has only README, no `.png` refs or `albedo_texture` refs were observed, Main Menu/Album use ColorRect, and Boat/Avatar/Pet/Decor are color-only primitive materials.

## Explicitly not changed
- no Scene/Resource/GDScript product implementation
- no new image generation
- no PR #19 changes
- no runtime evidence upgrade

The consumer manifest itself already exists on current main at `docs/visual/2026-08-26-game-image-consumer-manifest.md`; this PR aligns the active routers to it.