### PR TITLE
Define remaining game image goals and Codex handoff

### DIFF
--- a/docs/PROJECT_WORK_REUSE_HANDOFF.json
+++ b/docs/PROJECT_WORK_REUSE_HANDOFF.json
@@ -59,5 +59,66 @@
       "disposition": "ALREADY_COVERED_BY_BASE_POST_CHANGE_READBACK",
       "new_bcp_required": false
     }
-  ]
+  ],
+  "current_preflight_2026_08_26": {
+    "task": "REMAINING_GAME_IMAGE_GOALS_AND_CODEX_INTEGRATION_QUEUE",
+    "project_main_baseline": "d4d5e57027e1c83d1ae3504fce484fd4a11d8015",
+    "base_main_observed": "05d44bba978f4cff0fc94ade8e54825f5d6c80f0",
+    "selected_modules": [],
+    "reuse_mode": [
+      "REUSE_EXISTING_PROJECT_CANON",
+      "REUSE_APPROVED_VISUAL_REFERENCES",
+      "REUSE_APPROVED_CUSHION_AND_POSTCARD_MOTIFS_WITH_EDIT",
+      "REUSE_EXISTING_BOAT_DECOR_ITEM_AND_SLOT_SEMANTICS"
+    ],
+    "reuse_decisions": {
+      "visual_proof_01": "REUSE_AS_IS_REFERENCE",
+      "visual_proof_02": "REUSE_AS_IS_REFERENCE",
+      "image_a": "REUSE_AS_IS_REFERENCE",
+      "image_b": "REUSE_AS_IS_REFERENCE",
+      "cushion_sources": "REUSE_WITH_EDIT",
+      "postcard_sources": "REUSE_WITH_EDIT",
+      "main_menu_static_background": "REJECT_NOW",
+      "album_authored_images": "REJECT_NOW_USE_RUNTIME_CAPTURE",
+      "character_pet_fake_2d_portraits": "REJECT_USE_REAL_3D_PREVIEW",
+      "uv_specific_character_pet_boat_textures": "DEFER_BLOCKED_BY_PRODUCTION_GEOMETRY",
+      "sea_sky_bitmaps": "CONDITIONAL_ONLY_IF_RUNTIME_CONSUMER_REQUIRES",
+      "ui_icon_pack": "DEFER_NO_BINDING_CONSUMER"
+    },
+    "alternatives_reviewed": [
+      "A_BROAD_STATIC_IMAGE_PRODUCTION_NOW_REJECT",
+      "B_CONSUMER_STABLE_PLANAR_SURFACE_ASSETIZATION_ADOPT",
+      "C_UV_SPECIFIC_TEXTURE_PRODUCTION_BEFORE_GEOMETRY_REJECT_NOW_DEFER"
+    ],
+    "project_paths_changed": [
+      "docs/visual/2026-08-26-remaining-image-goals.md",
+      "docs/handoffs/2026-08-26-image-codex-integration-goals.md",
+      "docs/handoffs/CURRENT_PLANNING_VISUAL_WORK.md",
+      "docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md",
+      "docs/PROJECT_WORK_REUSE_HANDOFF.json"
+    ],
+    "verification_evidence": [
+      "fresh project main and Base main readback",
+      "project AGENTS and current Notion Home/Visual/Blueprint/Asset Library readback",
+      "current scenes and scripts confirm zero production image binaries/runtime image references",
+      "approved source motif hashes recorded in Notion Asset Library as WIP/NEEDS_REVISION",
+      "open PR #19 observed and kept READ_ONLY_NO_ABSORPTION"
+    ],
+    "evidence_ceiling": {
+      "goal_queue": "PLANNED",
+      "approved_reference_visuals": 4,
+      "approved_motif_source_images": 6,
+      "implementation_ready_image_assets": 0,
+      "implemented_image_assets": 0,
+      "runtime_verified_image_assets": 0,
+      "new_image_generation_this_task": "NOT_RUN"
+    },
+    "rollback": "Current task changes are planning/Notion records only; no Godot product files or image binaries are mutated. The task PR can be reverted independently; source image approval provenance remains preserved.",
+    "project_only_lessons": [
+      "Rendered object presentation images are not automatically valid runtime albedo assets; preserve approval while classifying runtime status separately.",
+      "For My Little Boat, the first justified authored runtime images are consumer-stable cushion surface motifs and postcard face art, not static menu backgrounds or fake selection portraits."
+    ],
+    "base_promotion_candidates": [],
+    "reuse_learning_handoff": "NO_NEW_REUSE_LEARNING_FOR_BASE"
+  }
 }

--- a/docs/PROJECT_WORK_REUSE_HANDOFF.json
+++ b/docs/PROJECT_WORK_REUSE_HANDOFF.json
@@ -68,7 +68,7 @@
     "reuse_mode": [
       "REUSE_EXISTING_PROJECT_CANON",
       "REUSE_APPROVED_VISUAL_REFERENCES",
-      "REUSE_APPROVED_CUSHION_AND_POSTCARD_MOTIFS_WITH_EDIT",
+      "REUSE_APPROVED_CUSHION_AND_POSTCARD_SOURCE_ART",
       "REUSE_EXISTING_BOAT_DECOR_ITEM_AND_SLOT_SEMANTICS"
     ],
     "reuse_decisions": {
@@ -76,14 +76,16 @@
       "visual_proof_02": "REUSE_AS_IS_REFERENCE",
       "image_a": "REUSE_AS_IS_REFERENCE",
       "image_b": "REUSE_AS_IS_REFERENCE",
-      "cushion_sources": "REUSE_WITH_EDIT",
-      "postcard_sources": "REUSE_WITH_EDIT",
-      "main_menu_static_background": "REJECT_NOW",
+      "cushion_sources": "REUSE_WITH_EDIT_ACTIVE_P1",
+      "bright_postcard_source": "REUSE_WITH_EDIT_ACTIVE_P1_DEFAULT_FACE",
+      "dawn_sunset_postcard_sources": "REUSE_LATER_P2_NO_CURRENT_VARIANT_CONSUMER",
+      "main_menu_static_background": "REJECT_NOW_NO_REQUIRED_AUTHORED_IMAGE",
       "album_authored_images": "REJECT_NOW_USE_RUNTIME_CAPTURE",
       "character_pet_fake_2d_portraits": "REJECT_USE_REAL_3D_PREVIEW",
       "uv_specific_character_pet_boat_textures": "DEFER_BLOCKED_BY_PRODUCTION_GEOMETRY",
       "sea_sky_bitmaps": "CONDITIONAL_ONLY_IF_RUNTIME_CONSUMER_REQUIRES",
-      "ui_icon_pack": "DEFER_NO_BINDING_CONSUMER"
+      "ui_icon_pack": "DEFER_NO_BINDING_CONSUMER",
+      "app_icon_store_marketing": "P3_HOLD_RELEASE_TARGET_AND_BRAND_LOCK"
     },
     "alternatives_reviewed": [
       "A_BROAD_STATIC_IMAGE_PRODUCTION_NOW_REJECT",
@@ -95,19 +97,24 @@
       "docs/handoffs/2026-08-26-image-codex-integration-goals.md",
       "docs/handoffs/CURRENT_PLANNING_VISUAL_WORK.md",
       "docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md",
+      "docs/visual/2026-08-26-game-image-consumer-manifest.md",
       "docs/PROJECT_WORK_REUSE_HANDOFF.json"
     ],
     "verification_evidence": [
       "fresh project main and Base main readback",
       "project AGENTS and current Notion Home/Visual/Blueprint/Asset Library readback",
-      "current scenes and scripts confirm zero production image binaries/runtime image references",
-      "approved source motif hashes recorded in Notion Asset Library as WIP/NEEDS_REVISION",
+      "current scenes/scripts confirm zero production image binaries and zero runtime image consumers",
+      "approved source hashes recorded in Notion Asset Library with runtime status separated from user visual approval",
+      "postcard overproduction finding corrected: P1 default face reduced from three to one; Dawn/Sunset retained as P2 reuse candidates",
       "open PR #19 observed and kept READ_ONLY_NO_ABSORPTION"
     ],
     "evidence_ceiling": {
-      "goal_queue": "PLANNED",
+      "goal_queue": "READY_FOR_USER_REVIEW",
       "approved_reference_visuals": 4,
-      "approved_motif_source_images": 6,
+      "approved_source_images": 6,
+      "active_p1_goals": 2,
+      "active_p1_required_files": 4,
+      "p0_authored_image_goals": 0,
       "implementation_ready_image_assets": 0,
       "implemented_image_assets": 0,
       "runtime_verified_image_assets": 0,
@@ -116,7 +123,7 @@
     "rollback": "Current task changes are planning/Notion records only; no Godot product files or image binaries are mutated. The task PR can be reverted independently; source image approval provenance remains preserved.",
     "project_only_lessons": [
       "Rendered object presentation images are not automatically valid runtime albedo assets; preserve approval while classifying runtime status separately.",
-      "For My Little Boat, the first justified authored runtime images are consumer-stable cushion surface motifs and postcard face art, not static menu backgrounds or fake selection portraits."
+      "Do not add a postcard variant system solely to consume every approved source image; one default face is sufficient for current P1 and the other approved compositions remain reusable P2 evidence."
     ],
     "base_promotion_candidates": [],
     "reuse_learning_handoff": "NO_NEW_REUSE_LEARNING_FOR_BASE"

--- a/docs/handoffs/2026-08-26-image-codex-integration-goals.md
+++ b/docs/handoffs/2026-08-26-image-codex-integration-goals.md
@@ -3,9 +3,9 @@
 Status: `PREPARED / BLOCKED_UNTIL_GPT_IMAGE_APPROVAL_COMPLETE`
 Date: 2026-08-26
 
-Codex does **not** create or redesign images. It integrates only GPT-produced, user-approved, Notion-registered assets.
+Codex does **not** create, redraw or edit images. It integrates only GPT-produced, user-approved, Notion-registered `IMPLEMENTATION_READY` assets.
 
-Before every Goal, Codex must fresh-read completed `main`, project Notion, actual scenes/scripts/resources/tests, and open PRs. PR #19 remains `READ_ONLY / NO_ABSORPTION`.
+Before every Goal, fresh-read completed `main`, Project Notion, actual scenes/scripts/resources/tests and current open PRs. PR #19 stays `READ_ONLY / NO_ABSORPTION`.
 
 ---
 
@@ -13,19 +13,18 @@ Before every Goal, Codex must fresh-read completed `main`, project Notion, actua
 
 ### Goal
 
-Connect the three approved pet-cushion surface images to the actual `pet_cushion` decor so the player can see/select the approved appearance variants without changing any rest, reward or care semantics.
+Connect the three approved final cushion surface images to the stable `pet_cushion` decor so the player can select three quiet appearance variants without changing rest, reward, care or economy semantics.
 
 ### Inputs
 
-- `IMG-01` approved assets and Notion records.
+- `IMG-01` approved files + Asset Library records.
 - `docs/visual/2026-08-26-remaining-image-goals.md`.
 - `scripts/decor/boat_decor_catalog.gd`.
 - `scripts/decor/boat_decor_slot.gd`.
-- `scenes/boat_space.tscn`.
-- `scenes/game.tscn`.
+- `scenes/boat_space.tscn` and `scenes/game.tscn`.
 - existing Boat Decoration / GameState tests.
 
-Expected asset paths:
+Expected exact files:
 
 ```text
 res://assets/images/decor/pet_cushion/cushion_stripe.png
@@ -35,110 +34,106 @@ res://assets/images/decor/pet_cushion/cushion_floral.png
 
 ### Scope
 
-- import approved textures;
-- establish the smallest safe `pet_cushion` visual variant representation;
-- connect the selected texture to the cushion material;
-- preserve fallback if an image is missing/invalid;
-- expose only enough existing decor UI/state to select the three approved visual variants;
-- preserve local-first state semantics and existing slot compatibility.
+- import the exact three approved images;
+- reuse the existing `pet_cushion` base item and `pet_corner` compatibility;
+- choose the smallest safe cosmetic variant-state representation;
+- connect selected surface to actual cushion material/geometry;
+- preserve neutral color fallback if texture is absent/invalid;
+- expose only enough existing decor UI/state to choose the three appearances.
 
 ### Non-Scope
 
-- no new pet needs/care loop;
-- no stats, rarity, currency, gacha or store;
-- no new decor slot ids;
-- no unrelated boat/item art replacement;
-- no PR #19 mutation;
-- no image creation/editing by Codex.
+- no new pet need/care loop;
+- no stats, rarity, currency, gacha, shop or completion bonus;
+- no new decor slot IDs or unrelated item replacement;
+- no social/PR #19 work;
+- no image creation/editing.
 
 ### Tasks
 
-1. Fresh-read current completed main and Notion asset records.
-2. Inspect existing `pet_cushion` item/slot/state contracts and current tests.
-3. Reuse current Boat Decoration flow; choose the smallest variant-state representation that preserves base `pet_cushion` meaning.
-4. Add semantic TDD RED for three available cushion appearances, missing-texture fallback, and core-state isolation.
-5. Import the approved PNGs using mobile-appropriate texture settings.
-6. Connect the actual material consumer.
-7. Connect variant selection without creating reward/progression meaning.
-8. Run focused tests and repository validation.
-9. Run Godot scene/runtime proof at 540×960 portrait.
-10. Capture evidence showing each variant on the actual pet cushion.
-11. Fix stretch, UV, scale, noise or state regressions.
-12. Return a `READY_FOR_GPT_REVIEW` packet with exact paths, head SHA, tests, runtime proof and remaining NOT_RUN evidence.
+1. Fresh-read current main/Notion and inspect existing cushion/decor contracts.
+2. Reuse current Boat Decoration architecture; avoid parallel inventory/system creation.
+3. Add semantic TDD RED for three cosmetic appearances, safe fallback and core-state isolation.
+4. Import exact approved files with mobile-appropriate settings.
+5. Establish the smallest viable cushion material mapping; current simple geometry may be refined only as needed to display the approved flat surfaces correctly.
+6. Connect appearance selection without altering base item compatibility or interaction meaning.
+7. Run focused regression + repository validation.
+8. Run actual game at 540×960 portrait.
+9. Capture runtime evidence for Stripe / Moon / Floral.
+10. Fix UV/repeat/stretch/mip/noise/state issues.
+11. Return `READY_FOR_GPT_REVIEW` with exact head, file refs, tests, screenshots and NOT_RUN evidence.
 
 ### Acceptance Criteria
 
-- all three **exact approved files** are importable and actually referenced by the runtime consumer;
-- switching cushion appearance does not change slot compatibility, rewards, timer, affection, social state or care obligation;
-- missing/invalid texture falls back safely instead of breaking the decor item;
-- no double-baked cushion geometry/shadow appears from the albedo;
-- texture scale is readable and calm at 540×960;
-- existing Boat Decoration and interaction behavior does not regress;
-- runtime screenshot evidence exists.
+- all three exact approved files are actually referenced by the runtime cushion consumer;
+- appearance switching changes only visuals;
+- missing texture falls back safely;
+- no double-baked cushion silhouette/shadow is visible;
+- motifs remain calm/readable at 540×960;
+- existing decoration/interaction/state semantics regress by 0;
+- runtime screenshots exist.
 
 ---
 
-## CODEX-IMG-02 — Postcard Memory Face Integration
+## CODEX-IMG-02 — Default Postcard Memory Face Integration
 
 ### Goal
 
-Connect the three approved postcard face images to the existing `postcard` decor so placed postcards visibly carry quiet memory art without turning them into collectible progression.
+Connect the one approved default Bright Boat postcard face to the existing `postcard` decor so it carries visible personal-memory artwork without creating a new postcard variant/collection system.
 
 ### Inputs
 
-- `IMG-02` approved assets and Notion records.
+- `IMG-02` approved final file + Asset Library record.
 - `docs/visual/2026-08-26-remaining-image-goals.md`.
 - `scripts/decor/boat_decor_catalog.gd`.
 - `scripts/decor/boat_decor_slot.gd`.
-- `scenes/boat_space.tscn`.
-- `scenes/game.tscn`.
+- `scenes/boat_space.tscn` and `scenes/game.tscn`.
 
-Expected paths:
+Expected exact file:
 
 ```text
-res://assets/images/decor/postcard/postcard_dawn.png
 res://assets/images/decor/postcard/postcard_boat_bright.png
-res://assets/images/decor/postcard/postcard_boat_sunset.png
 ```
+
+Dawn/Sunset source compositions are P2 reuse candidates and are **not** inputs to this P1 Goal.
 
 ### Scope
 
-- import three face textures;
-- apply one selected face to the existing postcard visual;
-- provide the smallest cosmetic variant path within the current decoration flow;
-- maintain rail/postcard interaction behavior;
-- verify small-object readability in the normal 3/4 camera.
+- import the exact approved default face;
+- connect it to the existing `postcard` visual;
+- preserve the existing `postcard` item ID, rail compatibility and `look` interaction;
+- preserve neutral fallback if texture is missing/invalid;
+- make only the minimal geometry/material change needed for correct front-face display.
 
 ### Non-Scope
 
-- no postcard rarity/collection score;
-- no new memory reward system;
-- no new album architecture;
-- no new social-letter feature;
+- no postcard variant selector/state;
+- no rarity/collection score/reward system;
+- no new Album architecture or social-letter feature;
 - no PR #19 work;
-- no image creation/editing by Codex.
+- no image creation/editing.
 
 ### Tasks
 
 1. Fresh-read main/Notion and current postcard behavior.
-2. Confirm actual face orientation/material/UV needs.
-3. Add semantic RED tests for three cosmetic faces, fallback and core-state isolation.
-4. Import approved files and bind them to the postcard front-face material.
-5. Connect minimal cosmetic selection while preserving base `postcard` item meaning.
-6. Verify `look` interaction still works.
-7. Run focused regression tests and full repository validation.
-8. Run actual game scene at 540×960 and inspect normal 3/4 view.
-9. Capture screenshots showing each face at runtime.
-10. Correct crop, aspect, UV orientation, mip/readability or visual-noise issues.
-11. Return `READY_FOR_GPT_REVIEW` packet.
+2. Confirm the simplest correct front-face geometry/material path; if the current BoxMesh cannot display a clean single face without unwanted side repetition, use the smallest visual-only geometry adjustment.
+3. Add semantic RED tests for exact texture consumer, fallback and core-state isolation.
+4. Import and bind the approved Bright Boat face.
+5. Verify existing `look` interaction and decor state remain intact.
+6. Run focused regression + full repository validation.
+7. Run actual game at 540×960 normal 3/4 view.
+8. Capture runtime screenshot proving the exact face is visible.
+9. Correct aspect/crop/mirroring/UV/mip/readability/noise issues.
+10. Return `READY_FOR_GPT_REVIEW` packet.
 
 ### Acceptance Criteria
 
-- the exact approved postcard files are loaded by the actual postcard consumer;
-- no card-face image is stretched, mirrored, clipped incorrectly or surrounded by presentation-space background/shadow;
-- the postcard remains a low-pressure decor/memory trace;
-- `look` interaction and existing decor state continue to work;
-- the sea/boat hierarchy remains dominant in the normal camera;
+- the exact approved Bright Boat file is loaded by the actual postcard consumer;
+- no external presentation canvas/shadow is visible;
+- image is not stretched, mirrored or incorrectly clipped;
+- no new postcard variant/progression system was introduced;
+- `look` interaction and existing decor state work unchanged;
+- postcard stays subordinate to the sea/boat hierarchy;
 - runtime screenshot evidence exists.
 
 ---
@@ -146,17 +141,16 @@ res://assets/images/decor/postcard/postcard_boat_sunset.png
 ## Cross-goal verification sequence
 
 ```text
-Approved image binary
-→ Notion asset record
+IMPLEMENTATION_READY approved image
 → Codex import
 → exact runtime consumer reference
-→ focused regression
+→ semantic regression
 → Godot runtime
 → 540×960 screenshot
 → GPT final review
 → merge
 → postmerge readback
-→ Notion Implementation/RUNTIME status update
+→ Notion IMPLEMENTED / RUNTIME_VERIFIED update
 ```
 
-No `IMPLEMENTED` or `RUNTIME_VERIFIED` status is allowed from planning, image approval or CI alone.
+Planning, image approval or CI alone never upgrades a file to `IMPLEMENTED` or `RUNTIME_VERIFIED`.

--- a/docs/handoffs/2026-08-26-image-codex-integration-goals.md
+++ b/docs/handoffs/2026-08-26-image-codex-integration-goals.md
@@ -1,0 +1,162 @@
+# My Little Boat — Codex Image Integration Goals
+
+Status: `PREPARED / BLOCKED_UNTIL_GPT_IMAGE_APPROVAL_COMPLETE`
+Date: 2026-08-26
+
+Codex does **not** create or redesign images. It integrates only GPT-produced, user-approved, Notion-registered assets.
+
+Before every Goal, Codex must fresh-read completed `main`, project Notion, actual scenes/scripts/resources/tests, and open PRs. PR #19 remains `READ_ONLY / NO_ABSORPTION`.
+
+---
+
+## CODEX-IMG-01 — Pet Cushion Runtime Surface Integration
+
+### Goal
+
+Connect the three approved pet-cushion surface images to the actual `pet_cushion` decor so the player can see/select the approved appearance variants without changing any rest, reward or care semantics.
+
+### Inputs
+
+- `IMG-01` approved assets and Notion records.
+- `docs/visual/2026-08-26-remaining-image-goals.md`.
+- `scripts/decor/boat_decor_catalog.gd`.
+- `scripts/decor/boat_decor_slot.gd`.
+- `scenes/boat_space.tscn`.
+- `scenes/game.tscn`.
+- existing Boat Decoration / GameState tests.
+
+Expected asset paths:
+
+```text
+res://assets/images/decor/pet_cushion/cushion_stripe.png
+res://assets/images/decor/pet_cushion/cushion_moon.png
+res://assets/images/decor/pet_cushion/cushion_floral.png
+```
+
+### Scope
+
+- import approved textures;
+- establish the smallest safe `pet_cushion` visual variant representation;
+- connect the selected texture to the cushion material;
+- preserve fallback if an image is missing/invalid;
+- expose only enough existing decor UI/state to select the three approved visual variants;
+- preserve local-first state semantics and existing slot compatibility.
+
+### Non-Scope
+
+- no new pet needs/care loop;
+- no stats, rarity, currency, gacha or store;
+- no new decor slot ids;
+- no unrelated boat/item art replacement;
+- no PR #19 mutation;
+- no image creation/editing by Codex.
+
+### Tasks
+
+1. Fresh-read current completed main and Notion asset records.
+2. Inspect existing `pet_cushion` item/slot/state contracts and current tests.
+3. Reuse current Boat Decoration flow; choose the smallest variant-state representation that preserves base `pet_cushion` meaning.
+4. Add semantic TDD RED for three available cushion appearances, missing-texture fallback, and core-state isolation.
+5. Import the approved PNGs using mobile-appropriate texture settings.
+6. Connect the actual material consumer.
+7. Connect variant selection without creating reward/progression meaning.
+8. Run focused tests and repository validation.
+9. Run Godot scene/runtime proof at 540×960 portrait.
+10. Capture evidence showing each variant on the actual pet cushion.
+11. Fix stretch, UV, scale, noise or state regressions.
+12. Return a `READY_FOR_GPT_REVIEW` packet with exact paths, head SHA, tests, runtime proof and remaining NOT_RUN evidence.
+
+### Acceptance Criteria
+
+- all three **exact approved files** are importable and actually referenced by the runtime consumer;
+- switching cushion appearance does not change slot compatibility, rewards, timer, affection, social state or care obligation;
+- missing/invalid texture falls back safely instead of breaking the decor item;
+- no double-baked cushion geometry/shadow appears from the albedo;
+- texture scale is readable and calm at 540×960;
+- existing Boat Decoration and interaction behavior does not regress;
+- runtime screenshot evidence exists.
+
+---
+
+## CODEX-IMG-02 — Postcard Memory Face Integration
+
+### Goal
+
+Connect the three approved postcard face images to the existing `postcard` decor so placed postcards visibly carry quiet memory art without turning them into collectible progression.
+
+### Inputs
+
+- `IMG-02` approved assets and Notion records.
+- `docs/visual/2026-08-26-remaining-image-goals.md`.
+- `scripts/decor/boat_decor_catalog.gd`.
+- `scripts/decor/boat_decor_slot.gd`.
+- `scenes/boat_space.tscn`.
+- `scenes/game.tscn`.
+
+Expected paths:
+
+```text
+res://assets/images/decor/postcard/postcard_dawn.png
+res://assets/images/decor/postcard/postcard_boat_bright.png
+res://assets/images/decor/postcard/postcard_boat_sunset.png
+```
+
+### Scope
+
+- import three face textures;
+- apply one selected face to the existing postcard visual;
+- provide the smallest cosmetic variant path within the current decoration flow;
+- maintain rail/postcard interaction behavior;
+- verify small-object readability in the normal 3/4 camera.
+
+### Non-Scope
+
+- no postcard rarity/collection score;
+- no new memory reward system;
+- no new album architecture;
+- no new social-letter feature;
+- no PR #19 work;
+- no image creation/editing by Codex.
+
+### Tasks
+
+1. Fresh-read main/Notion and current postcard behavior.
+2. Confirm actual face orientation/material/UV needs.
+3. Add semantic RED tests for three cosmetic faces, fallback and core-state isolation.
+4. Import approved files and bind them to the postcard front-face material.
+5. Connect minimal cosmetic selection while preserving base `postcard` item meaning.
+6. Verify `look` interaction still works.
+7. Run focused regression tests and full repository validation.
+8. Run actual game scene at 540×960 and inspect normal 3/4 view.
+9. Capture screenshots showing each face at runtime.
+10. Correct crop, aspect, UV orientation, mip/readability or visual-noise issues.
+11. Return `READY_FOR_GPT_REVIEW` packet.
+
+### Acceptance Criteria
+
+- the exact approved postcard files are loaded by the actual postcard consumer;
+- no card-face image is stretched, mirrored, clipped incorrectly or surrounded by presentation-space background/shadow;
+- the postcard remains a low-pressure decor/memory trace;
+- `look` interaction and existing decor state continue to work;
+- the sea/boat hierarchy remains dominant in the normal camera;
+- runtime screenshot evidence exists.
+
+---
+
+## Cross-goal verification sequence
+
+```text
+Approved image binary
+→ Notion asset record
+→ Codex import
+→ exact runtime consumer reference
+→ focused regression
+→ Godot runtime
+→ 540×960 screenshot
+→ GPT final review
+→ merge
+→ postmerge readback
+→ Notion Implementation/RUNTIME status update
+```
+
+No `IMPLEMENTED` or `RUNTIME_VERIFIED` status is allowed from planning, image approval or CI alone.

--- a/docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
+++ b/docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
@@ -7,8 +7,10 @@
 ```yaml
 project: MY_LITTLE_BOAT
 mode: CODEX_GODOT_PRODUCT_IMPLEMENTATION_HANDOFF
-status: PAUSED_PENDING_CONSUMER_CONTRACTS
+status: PAUSED_UNTIL_ACTIVE_IMAGE_GOALS_IMPLEMENTATION_READY
 current_work_router: docs/handoffs/CURRENT_PLANNING_VISUAL_WORK.md
+image_goal_source: docs/visual/2026-08-26-remaining-image-goals.md
+codex_image_goal_source: docs/handoffs/2026-08-26-image-codex-integration-goals.md
 image_asset_policy: CONSUMER_FIRST_ASSET
 implementation_baseline: RESOLVE_CURRENT_COMPLETED_MAIN_AT_CODEX_START
 implementation_owner_after_unpause: CODEX_GODOT_PRODUCT_IMPLEMENTATION_OWNER
@@ -17,7 +19,53 @@ concurrent_pr_19: READ_ONLY_NO_ABSORPTION
 image_generation_by_codex: FORBIDDEN
 ```
 
-The user corrected the visual pipeline: do not build explanatory image sheets as deliverables. Produce only image files with a concrete game/runtime consumer.
+## Binding pipeline
+
+The latest user instruction requires image planning/production to finish **before** Codex product integration for the active image goals:
+
+```text
+Remaining Image Goals
+→ user goal approval
+→ GPT image generation/editing
+→ GPT review
+→ user image approval
+→ Notion asset registration
+→ IMPLEMENTATION_READY
+→ Codex Integration Goals
+→ Godot import/wiring
+→ runtime screenshots/play verification
+→ GPT final review
+```
+
+Do not ask Codex to create/edit images. Do not start CODEX-IMG-01 or CODEX-IMG-02 while their image files are below `IMPLEMENTATION_READY`.
+
+## Active image integration goals waiting downstream
+
+### CODEX-IMG-01 — Pet Cushion Runtime Surface Integration
+
+Waits for:
+
+```text
+res://assets/images/decor/pet_cushion/cushion_stripe.png
+res://assets/images/decor/pet_cushion/cushion_moon.png
+res://assets/images/decor/pet_cushion/cushion_floral.png
+```
+
+These are three cosmetic visual variants of the stable `pet_cushion` meaning. Implementation must not create stats, rarity, cost, gacha, care obligation or a separate progression system.
+
+### CODEX-IMG-02 — Postcard Memory Face Integration
+
+Waits for:
+
+```text
+res://assets/images/decor/postcard/postcard_dawn.png
+res://assets/images/decor/postcard/postcard_boat_bright.png
+res://assets/images/decor/postcard/postcard_boat_sunset.png
+```
+
+These are cosmetic visual variants of the stable `postcard` meaning. They must remain quiet decor/memory traces.
+
+Full implementation tasks/acceptance are in `docs/handoffs/2026-08-26-image-codex-integration-goals.md`.
 
 ## Approved customization semantics waiting downstream
 
@@ -34,107 +82,58 @@ PET_SELECTION_SET
 + OTTER_LIKE
 
 PET_CUSHION_CUSTOMIZATION
-= APPROVED_AT_FEATURE_MEANING_LEVEL
+= THREE_APPROVED_VISUAL_VARIANTS / COSMETIC_ONLY
 ```
 
-These are cosmetic/personalization choices only. They must not create class/stat/rarity/gacha/monetization/progression differences.
+The exact Godot variant-state representation remains Codex's implementation choice after fresh-read. Preserve existing `pet_cushion` and `postcard` base semantics and current decor compatibility.
 
-## Image-consumer rule
+## Do not invent image consumers for deferred categories
 
-Before an image asset is generated, planning must define:
+- Main Menu / Album authored backgrounds are not required; current ColorRect/live-world routes remain valid.
+- character/pet selection thumbnails should derive from actual 3D previews.
+- exact UV-specific character/pet/boat texture sheets stay blocked by production geometry.
+- sky/sea bitmap assets are conditional on actual material technique; prefer simple color/light/procedural methods.
+- UI icons remain deferred until a binding runtime need exists.
+- release/store art is P3 and not this implementation slice.
 
-```text
-asset_path
-consumer
-runtime_role
-spec
-fallback
-validation
-```
+## Codex unpause gate
 
-An image is not DONE until the intended Godot consumer loads the exact file and runtime evidence shows it in use.
-
-Current main has no production image consumer yet:
+Both active image goals must be ready unless the user explicitly narrows the batch:
 
 ```text
-assets/images = README only
-.png references = 0 observed
-albedo_texture references = 0 observed
-Main Menu / Album = ColorRect backgrounds
-Boat / Avatar / Pet = primitive mesh + color-only material
-Decor = primitive mesh + albedo_color
-```
-
-## First candidate consumer batches
-
-### Pet cushion textures
-
-Target meaning:
-- `item_id = pet_cushion`
-- intended material property = `StandardMaterial3D.albedo_texture`
-- runtime role = player-visible pet-cushion appearance customization
-
-### Postcard textures
-
-Target meaning:
-- `item_id = postcard`
-- intended material property = `StandardMaterial3D.albedo_texture`
-- runtime role = authored visible postcard/memory artwork
-
-These are candidates, not yet implemented consumers.
-
-## Deferred image categories
-
-Do not create until the corresponding consumer exists:
-
-- character/pet albedo textures → production mesh + UV required;
-- boat/general decor textures → production mesh + UV required unless a stable primitive consumer is intentionally retained;
-- sky/time-of-day bitmaps → only if Environment adopts panorama/sky textures;
-- sea normal/noise maps → only if the sea material/shader samples them;
-- UI icons → only after TextureButton/TextureRect/theme-icon consumers are approved;
-- main-menu/album backgrounds → current ColorRect means no image asset is needed.
-
-`Image C / Representative Visual GDD` is cancelled as a required production image.
-
-## Unpause gate
-
-Godot product implementation may resume for a consumer-first asset slice when all are true for at least one asset batch:
-
-```text
-ASSET_CONSUMER_CONTRACT = APPROVED
-ASSET_PATH = FIXED
-CONSUMER_TARGET = FIXED
-IMPORT_SPEC = FIXED
-RUNTIME_ROLE = FIXED
-FALLBACK_BEHAVIOR = FIXED
-TDD/VALIDATION_PLAN = READY
+IMG_01_FILES = IMPLEMENTATION_READY
+IMG_01_NOTION_READBACK = PASS
+IMG_02_FILES = IMPLEMENTATION_READY
+IMG_02_NOTION_READBACK = PASS
+EXACT_ASSET_PATHS = FIXED
+CODEX_INTEGRATION_GOALS = CURRENT
 PR_19 = READ_ONLY_NO_ABSORPTION
 ```
 
-Then Codex may implement the smallest safe consumer wiring. After the consumer exists and is validated, GPT image generation may produce the exact asset for that consumer, followed by runtime integration verification.
+At Codex start, fresh-read current completed main, Notion, actual Godot files/tests, current open PRs, and toolchain. Use semantic TDD and runtime proof. Do not treat historical exact Node/test sketches as binding implementation internals.
 
 ## Protected downstream scope
 
 - rest-first Core Loop, voyage duration/rewards, and mood meaning;
 - Normal vs Appreciation Camera semantics and input isolation;
 - BoatSpace shared bob ownership;
-- 8 decor slot IDs and six current item IDs/compatibility/state meaning;
+- 8 decor slot IDs and existing six base item meanings/compatibility;
 - low-pressure interaction reward isolation;
-- care-obligation-free pet semantics across selectable species;
-- cosmetic selection must not alter rewards, timer, progression pressure, social eligibility, or care obligation;
+- care-obligation-free pet semantics;
+- cosmetic variants must not alter rewards, timer, progression pressure, social eligibility or care obligation;
 - local-first core;
-- PR #19 remains an independent workstream unless explicitly reopened.
+- PR #19 remains an independent workstream.
 
 ## Evidence ceiling while paused
 
 ```text
-CONSUMER_FIRST_ASSET_POLICY = ACTIVE
-REFERENCE_IMAGES = APPROVED_BUT_NOT_RUNTIME_ASSETS
-CURRENT_RUNTIME_IMAGE_CONSUMERS = 0
-PET_CUSHION_TEXTURES = CONSUMER_CONTRACT_CANDIDATE
-POSTCARD_TEXTURES = CONSUMER_CONTRACT_CANDIDATE
-NEW_GAME_IMAGE_GENERATION = PAUSED
-PRODUCT_TDD_RED_GREEN = NOT_RUN
+IMAGE_GOAL_QUEUE = READY_FOR_USER_REVIEW
+IMG_01 = NEEDS_REVISION
+IMG_02 = NEEDS_REVISION
+CODEX_IMG_01 = NOT_RUN
+CODEX_IMG_02 = NOT_RUN
+IMPLEMENTED_IMAGE_ASSETS = 0
+RUNTIME_VERIFIED_IMAGE_ASSETS = 0
 HANDPAINTED_3D_RUNTIME_SLICE = NOT_RUN
 REAL_DEVICE_TOUCH_QA = NOT_RUN
 ```

--- a/docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
+++ b/docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
@@ -21,14 +21,12 @@ image_generation_by_codex: FORBIDDEN
 
 ## Binding pipeline
 
-The latest user instruction requires image planning/production to finish **before** Codex product integration for the active image goals:
-
 ```text
 Remaining Image Goals
 → user goal approval
 → GPT image generation/editing
 → GPT review
-→ user image approval
+→ user asset approval
 → Notion asset registration
 → IMPLEMENTATION_READY
 → Codex Integration Goals
@@ -37,13 +35,13 @@ Remaining Image Goals
 → GPT final review
 ```
 
-Do not ask Codex to create/edit images. Do not start CODEX-IMG-01 or CODEX-IMG-02 while their image files are below `IMPLEMENTATION_READY`.
+Codex does not create/edit images and does not start CODEX-IMG-01/02 before their required files are `IMPLEMENTATION_READY`.
 
 ## Active image integration goals waiting downstream
 
 ### CODEX-IMG-01 — Pet Cushion Runtime Surface Integration
 
-Waits for:
+Waits for exactly:
 
 ```text
 res://assets/images/decor/pet_cushion/cushion_stripe.png
@@ -51,21 +49,19 @@ res://assets/images/decor/pet_cushion/cushion_moon.png
 res://assets/images/decor/pet_cushion/cushion_floral.png
 ```
 
-These are three cosmetic visual variants of the stable `pet_cushion` meaning. Implementation must not create stats, rarity, cost, gacha, care obligation or a separate progression system.
+Three cosmetic visual variants of the existing `pet_cushion` meaning. No stat/rarity/cost/gacha/care/progression semantics.
 
-### CODEX-IMG-02 — Postcard Memory Face Integration
+### CODEX-IMG-02 — Default Postcard Memory Face Integration
 
-Waits for:
+Waits for exactly:
 
 ```text
-res://assets/images/decor/postcard/postcard_dawn.png
 res://assets/images/decor/postcard/postcard_boat_bright.png
-res://assets/images/decor/postcard/postcard_boat_sunset.png
 ```
 
-These are cosmetic visual variants of the stable `postcard` meaning. They must remain quiet decor/memory traces.
+P1 integrates one default visual face only. Dawn/Sunset source compositions are P2 reuse candidates; **do not** create a postcard variant selector/state merely to use them.
 
-Full implementation tasks/acceptance are in `docs/handoffs/2026-08-26-image-codex-integration-goals.md`.
+Full tasks/acceptance: `docs/handoffs/2026-08-26-image-codex-integration-goals.md`.
 
 ## Approved customization semantics waiting downstream
 
@@ -83,53 +79,56 @@ PET_SELECTION_SET
 
 PET_CUSHION_CUSTOMIZATION
 = THREE_APPROVED_VISUAL_VARIANTS / COSMETIC_ONLY
+
+POSTCARD_P1
+= ONE_APPROVED_DEFAULT_FACE / NO_VARIANT_SYSTEM
 ```
 
-The exact Godot variant-state representation remains Codex's implementation choice after fresh-read. Preserve existing `pet_cushion` and `postcard` base semantics and current decor compatibility.
+Exact Godot implementation details remain Codex choices after fresh-read. Preserve existing `pet_cushion` and `postcard` base meanings and compatibility.
 
-## Do not invent image consumers for deferred categories
+## Deferred consumers
 
-- Main Menu / Album authored backgrounds are not required; current ColorRect/live-world routes remain valid.
-- character/pet selection thumbnails should derive from actual 3D previews.
-- exact UV-specific character/pet/boat texture sheets stay blocked by production geometry.
-- sky/sea bitmap assets are conditional on actual material technique; prefer simple color/light/procedural methods.
-- UI icons remain deferred until a binding runtime need exists.
-- release/store art is P3 and not this implementation slice.
+Do not invent consumers to absorb extra art:
+
+- Main Menu/Album authored backgrounds are not required now.
+- character/pet selection thumbnails derive from actual 3D previews.
+- exact UV-specific character/pet/boat texture sheets are blocked by production geometry.
+- sky/sea bitmap assets are conditional; prefer simple color/light/procedural route.
+- UI icons are deferred until a binding consumer/readability need exists.
+- app icon/store/marketing is P3 after release targets/branding lock.
 
 ## Codex unpause gate
 
-Both active image goals must be ready unless the user explicitly narrows the batch:
-
 ```text
-IMG_01_FILES = IMPLEMENTATION_READY
+IMG_01_3_FILES = IMPLEMENTATION_READY
 IMG_01_NOTION_READBACK = PASS
-IMG_02_FILES = IMPLEMENTATION_READY
+IMG_02_1_FILE = IMPLEMENTATION_READY
 IMG_02_NOTION_READBACK = PASS
 EXACT_ASSET_PATHS = FIXED
 CODEX_INTEGRATION_GOALS = CURRENT
 PR_19 = READ_ONLY_NO_ABSORPTION
 ```
 
-At Codex start, fresh-read current completed main, Notion, actual Godot files/tests, current open PRs, and toolchain. Use semantic TDD and runtime proof. Do not treat historical exact Node/test sketches as binding implementation internals.
+At Codex start, fresh-read current completed main, Notion, actual Godot files/tests, open PRs and toolchain. Use semantic TDD and runtime proof.
 
 ## Protected downstream scope
 
-- rest-first Core Loop, voyage duration/rewards, and mood meaning;
-- Normal vs Appreciation Camera semantics and input isolation;
+- rest-first Core Loop, voyage duration/rewards and mood meaning;
+- Normal/Appreciation Camera semantics and input isolation;
 - BoatSpace shared bob ownership;
 - 8 decor slot IDs and existing six base item meanings/compatibility;
 - low-pressure interaction reward isolation;
 - care-obligation-free pet semantics;
-- cosmetic variants must not alter rewards, timer, progression pressure, social eligibility or care obligation;
+- cosmetic visuals must not alter rewards, timer, progression pressure, social eligibility or care obligation;
 - local-first core;
-- PR #19 remains an independent workstream.
+- PR #19 remains independent.
 
 ## Evidence ceiling while paused
 
 ```text
 IMAGE_GOAL_QUEUE = READY_FOR_USER_REVIEW
-IMG_01 = NEEDS_REVISION
-IMG_02 = NEEDS_REVISION
+IMG_01 = NEEDS_REVISION / 3 REQUIRED FILES
+IMG_02 = NEEDS_REVISION / 1 REQUIRED FILE
 CODEX_IMG_01 = NOT_RUN
 CODEX_IMG_02 = NOT_RUN
 IMPLEMENTED_IMAGE_ASSETS = 0

--- a/docs/handoffs/CURRENT_PLANNING_VISUAL_WORK.md
+++ b/docs/handoffs/CURRENT_PLANNING_VISUAL_WORK.md
@@ -1,147 +1,126 @@
 # Current Planning & Visual Work
 
-> Stable current-work router for `MY_LITTLE_BOAT` image production.
+> Stable current-work router for `MY_LITTLE_BOAT` game-consumable image production.
 
 ## Current task
 
 ```yaml
 project: MY_LITTLE_BOAT
-mode: GPT_GAME_IMAGE_CONSUMER_PLANNING
-current_goal: DEFINE_REAL_GAME_IMAGE_CONSUMERS_BEFORE_GENERATION
+mode: GPT_REMAINING_IMAGE_GOALS
 current_owner: GPT_NONCODING_PLANNING_VISUAL_OWNER
-concurrent_pr_19: READ_ONLY_NO_ABSORPTION
 policy: CONSUMER_FIRST_ASSET
-image_generation: PAUSED_UNTIL_CONSUMER_READY
-status: CONSUMER_MANIFEST_IN_PROGRESS
+current_goal: REVIEW_AND_COMPLETE_ACTIVE_IMAGE_GOALS_BEFORE_CODEX
+status: GOAL_QUEUE_READY_FOR_USER_REVIEW
+concurrent_pr_19: READ_ONLY_NO_ABSORPTION
+codex_product_build: HOLD_UNTIL_ACTIVE_IMAGES_IMPLEMENTATION_READY
 ```
 
-The user explicitly corrected the image-production rule:
+Latest user pipeline is binding:
 
-> Create images only when they have a real game consumer. Do not create explanatory sheets as deliverables.
+```text
+current canon/runtime audit
+→ existing image inventory + reuse check
+→ consumer gap analysis
+→ Remaining Image Goals
+→ user review/approval
+→ GPT image production
+→ Notion registration
+→ Codex Integration Goals
+→ Codex implementation
+→ runtime screenshots/play verification
+```
 
-## Authority
+Do not ask Codex to create images. Do not require Codex to create an image consumer before GPT image production when the consumer contract can already be defined safely from approved product semantics.
 
-Human/product authority:
+## Current authority/support
+
+Human canon:
 - Notion Human Home: `3c41b237-eb1c-8194-8b8e-d88362cafafa`
 - Notion Visual Bible: `3c11b237-eb1c-81ae-97f3-dc28a0905304`
 - Notion Asset Library: `3c11b237-eb1c-8120-b7db-d48e11756146`
 - Notion Visual Production Checklist: `3c81b237-eb1c-810c-b3f8-fce023a453cb`
+- Notion Game Image Blueprint: `3c81b237-eb1c-81dd-bc85-d0eb927671c8`
 
-Repository authority/support:
-- consumer manifest: `docs/visual/2026-08-26-game-image-consumer-manifest.md`
-- approved Image A customization decision: `docs/visual/2026-08-26-image-a-customization-decision.md`
-- paused Godot handoff: `docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md`
+Repository planning:
+- remaining image goal queue: `docs/visual/2026-08-26-remaining-image-goals.md`
+- consumer audit/manifest: `docs/visual/2026-08-26-game-image-consumer-manifest.md`
+- Codex integration goal queue: `docs/handoffs/2026-08-26-image-codex-integration-goals.md`
+- downstream Godot router: `docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md`
 
-## Reference images already approved
+## Current image state
 
-The following are preserved as planning references, but are **not counted as runtime image assets**:
+```text
+APPROVED_REFERENCE_VISUALS = 4
+APPROVED_MOTIF_SOURCE_IMAGES = 6
+IMPLEMENTATION_READY_IMAGE_ASSETS = 0
+IMPLEMENTED_IMAGE_ASSETS = 0
+RUNTIME_VERIFIED_IMAGE_ASSETS = 0
+P0_AUTHORED_IMAGE_GOALS = 0
+ACTIVE_P1_IMAGE_GOALS = 2
+```
 
+Approved references retained but not runtime assets:
 - Visual Proof 01
 - Visual Proof 02
 - Image A — Player + Pet Customization Board
 - Image B — Boat / Sea / Four-Time Atmosphere Board
 
-`Image C / Representative Visual GDD` is cancelled as a required image deliverable.
+The six approved cushion/postcard generated images preserve approved motif/color/composition decisions, but their current presentation-render form is not a production albedo/face asset. They are `NEEDS_REVISION` for runtime use.
 
-## Current-main runtime audit
+## Active Image Goal Queue
 
-Current main currently has no production image consumer:
+### IMG-01 — Pet Cushion Runtime Surface Set · P1
+
+Produce exactly three flat surface files from the approved motifs:
 
 ```text
-assets/images = README only
-.png references = 0 observed
-albedo_texture references = 0 observed
-Main Menu = ColorRect background
-Album = ColorRect background
-Boat/Avatar/Pet = primitive mesh + color-only StandardMaterial3D
-Decor = primitive mesh + albedo_color construction
+cushion_stripe.png
+cushion_moon.png
+cushion_floral.png
 ```
 
-Therefore:
+They must not contain rendered cushion geometry, rim, drop shadow, tuft depth or baked directional lighting.
+
+### IMG-02 — Postcard Memory Face Set · P1
+
+Produce exactly three normalized 4:3 postcard face files from the approved compositions:
 
 ```text
-CURRENT_RUNTIME_IMAGE_CONSUMERS = 0
+postcard_dawn.png
+postcard_boat_bright.png
+postcard_boat_sunset.png
 ```
 
-Do not generate another gameplay image until a concrete consumer contract is ready.
+They must not contain external presentation canvas/drop shadow around the intended card face.
 
-## Consumer-first rule
+## Explicit non-goals / deferred
 
-Every generated game image must have all six before generation:
+Do not create now:
+- Main Menu static background — current ColorRect is sufficient; a static image would invent a new consumer and may diverge from the actual 3D game.
+- Album authored screenshots — eventual photos should be runtime captures.
+- fake 2D character/pet portraits — selection thumbnails should derive from the real 3D assets.
+- exact character/pet/boat UV sheets — blocked until production geometry/consumer exists.
+- sky/sea bitmaps — conditional on actual material/shader technique; prefer simple color/light/procedural route.
+- UI icon pack — current text controls work; only reopen after a binding icon consumer/polish need.
+- release/store art — P3 and platform/branding dependent.
 
-```text
-asset_path
-consumer
-runtime_role
-spec
-fallback
-validation
-```
+## After user approves this queue
 
-A generated image is DONE only after the intended Godot consumer actually loads it and it is visible in runtime evidence.
-
-## First candidate consumers
-
-### Pet cushion textures
+Proceed in order:
 
 ```text
-item_id = pet_cushion
-intended consumer = Boat Decoration pet cushion material
-intended property = StandardMaterial3D.albedo_texture
-runtime role = player-visible cushion appearance customization
-```
-
-This is the strongest first candidate because the user already approved pet cushion customization and the stable item id already exists.
-
-### Postcard textures
-
-```text
-item_id = postcard
-intended consumer = Boat Decoration postcard material
-intended property = StandardMaterial3D.albedo_texture
-runtime role = authored personal/memory image on placed postcard decor
-```
-
-This is also strong because the item id already exists and the visual surface is naturally image-driven.
-
-## Deferred until consumer exists
-
-Do not generate these yet:
-
-- character/pet albedo textures — blocked by production mesh + UV;
-- boat/general decor textures — blocked by production mesh + UV unless current primitives are deliberately retained;
-- sky/time-of-day bitmaps — only if Environment adopts a panorama/sky texture consumer;
-- sea normal/noise maps — only if the sea material/shader actually samples them;
-- UI icons — only after a TextureButton/TextureRect/theme-icon consumer is approved;
-- main-menu/album backgrounds — current screens use ColorRect, so no image is needed now.
-
-## Runtime-generated images
-
-- Album/voyage photos should come from actual runtime capture, not authored concept art.
-- Character/pet selection thumbnails should preferably derive from the real production 3D assets so the thumbnail matches what the player receives.
-
-## Current next work
-
-```text
-1. Freeze explanatory-image production.
-2. Complete the game image consumer manifest.
-3. Promote only one small consumer batch to READY_TO_GENERATE.
-4. Recommended first batch: pet cushion textures + postcard textures.
-5. Define exact file path, size, alpha/color-space/import behavior and runtime consumer.
-6. Only then generate those image assets.
-7. Godot product owner wires them and proves exact-file runtime consumption.
+IMG-01 text contract → generate/edit → review → user approval → Notion registration
+IMG-02 text contract → generate/edit → review → user approval → Notion registration
+then update downstream handoff to READY_FOR_CODEX_IMAGE_INTEGRATION
 ```
 
 ## Evidence ceiling
 
 ```text
-CONSUMER_FIRST_ASSET_POLICY = ACTIVE
-REFERENCE_IMAGES = APPROVED_BUT_NOT_RUNTIME_ASSETS
-IMAGE_C_REPRESENTATIVE_VISUAL_GDD = CANCELLED
-CURRENT_RUNTIME_IMAGE_CONSUMERS = 0
-PET_CUSHION_TEXTURES = CONSUMER_CONTRACT_CANDIDATE
-POSTCARD_TEXTURES = CONSUMER_CONTRACT_CANDIDATE
-NEW_GAME_IMAGE_GENERATION = PAUSED
-HANDPAINTED_3D_RUNTIME_SLICE = NOT_RUN
-REAL_DEVICE_QA = NOT_RUN
+GOAL_QUEUE = READY_FOR_USER_REVIEW
+NEW_IMAGE_GENERATION_FOR_GOALS = NOT_RUN
+CODEX_IMAGE_INTEGRATION = NOT_RUN
+GODOT_RUNTIME = NOT_RUN
+MOBILE_30S_REVIEW = NOT_RUN
+MOBILE_5M_REVIEW = NOT_RUN
 ```

--- a/docs/handoffs/CURRENT_PLANNING_VISUAL_WORK.md
+++ b/docs/handoffs/CURRENT_PLANNING_VISUAL_WORK.md
@@ -15,22 +15,23 @@ concurrent_pr_19: READ_ONLY_NO_ABSORPTION
 codex_product_build: HOLD_UNTIL_ACTIVE_IMAGES_IMPLEMENTATION_READY
 ```
 
-Latest user pipeline is binding:
+Latest binding pipeline:
 
 ```text
 current canon/runtime audit
 → existing image inventory + reuse check
 → consumer gap analysis
 → Remaining Image Goals
-→ user review/approval
-→ GPT image production
+→ user goal approval
+→ GPT image production/review
+→ user asset approval
 → Notion registration
 → Codex Integration Goals
 → Codex implementation
 → runtime screenshots/play verification
 ```
 
-Do not ask Codex to create images. Do not require Codex to create an image consumer before GPT image production when the consumer contract can already be defined safely from approved product semantics.
+Codex does not create/edit images and must not start the active image integrations before the required files are `IMPLEMENTATION_READY`.
 
 ## Current authority/support
 
@@ -42,36 +43,37 @@ Human canon:
 - Notion Game Image Blueprint: `3c81b237-eb1c-81dd-bc85-d0eb927671c8`
 
 Repository planning:
-- remaining image goal queue: `docs/visual/2026-08-26-remaining-image-goals.md`
-- consumer audit/manifest: `docs/visual/2026-08-26-game-image-consumer-manifest.md`
-- Codex integration goal queue: `docs/handoffs/2026-08-26-image-codex-integration-goals.md`
-- downstream Godot router: `docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md`
+- current Goal Queue: `docs/visual/2026-08-26-remaining-image-goals.md`
+- consumer manifest: `docs/visual/2026-08-26-game-image-consumer-manifest.md`
+- Codex integration goals: `docs/handoffs/2026-08-26-image-codex-integration-goals.md`
+- downstream router: `docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md`
 
 ## Current image state
 
 ```text
 APPROVED_REFERENCE_VISUALS = 4
-APPROVED_MOTIF_SOURCE_IMAGES = 6
+APPROVED_SOURCE_IMAGES = 6
+ACTIVE_P1_IMAGE_GOALS = 2
+ACTIVE_P1_REQUIRED_FILES = 4
+P0_AUTHORED_IMAGE_GOALS = 0
 IMPLEMENTATION_READY_IMAGE_ASSETS = 0
 IMPLEMENTED_IMAGE_ASSETS = 0
 RUNTIME_VERIFIED_IMAGE_ASSETS = 0
-P0_AUTHORED_IMAGE_GOALS = 0
-ACTIVE_P1_IMAGE_GOALS = 2
 ```
 
-Approved references retained but not runtime assets:
+Reference-only approved visuals:
 - Visual Proof 01
 - Visual Proof 02
 - Image A — Player + Pet Customization Board
 - Image B — Boat / Sea / Four-Time Atmosphere Board
 
-The six approved cushion/postcard generated images preserve approved motif/color/composition decisions, but their current presentation-render form is not a production albedo/face asset. They are `NEEDS_REVISION` for runtime use.
+Six generated source images retain user-approved motif/composition decisions. They are not direct runtime files: 3 cushion sources and the Bright Boat postcard source are `REUSE_WITH_EDIT`; Dawn/Sunset postcard sources are P2 reuse candidates until a real multi-postcard consumer exists.
 
 ## Active Image Goal Queue
 
 ### IMG-01 — Pet Cushion Runtime Surface Set · P1
 
-Produce exactly three flat surface files from the approved motifs:
+Required flat files:
 
 ```text
 cushion_stripe.png
@@ -79,39 +81,38 @@ cushion_moon.png
 cushion_floral.png
 ```
 
-They must not contain rendered cushion geometry, rim, drop shadow, tuft depth or baked directional lighting.
+Must be 1024×1024 opaque sRGB low-frequency/repeat-friendly surface art with no rendered cushion form, rim, drop shadow, tuft depth or directional baked lighting.
 
-### IMG-02 — Postcard Memory Face Set · P1
+### IMG-02 — Default Postcard Memory Face · P1
 
-Produce exactly three normalized 4:3 postcard face files from the approved compositions:
+Required file:
 
 ```text
-postcard_dawn.png
 postcard_boat_bright.png
-postcard_boat_sunset.png
 ```
 
-They must not contain external presentation canvas/drop shadow around the intended card face.
+Must be one normalized 1024×768 4:3 postcard face with no external presentation canvas/drop shadow. No new postcard variant selector/state is part of P1.
 
-## Explicit non-goals / deferred
+Dawn/Sunset postcard compositions remain approved P2 reuse candidates and are not active required files.
 
-Do not create now:
-- Main Menu static background — current ColorRect is sufficient; a static image would invent a new consumer and may diverge from the actual 3D game.
+## Explicit deferred / no-goal categories
+
+- Main Menu static background — no required authored image; current ColorRect is valid and a static image would invent a consumer.
 - Album authored screenshots — eventual photos should be runtime captures.
-- fake 2D character/pet portraits — selection thumbnails should derive from the real 3D assets.
-- exact character/pet/boat UV sheets — blocked until production geometry/consumer exists.
-- sky/sea bitmaps — conditional on actual material/shader technique; prefer simple color/light/procedural route.
-- UI icon pack — current text controls work; only reopen after a binding icon consumer/polish need.
-- release/store art — P3 and platform/branding dependent.
+- fake 2D character/pet portraits — derive selection thumbnails from actual 3D assets.
+- exact character/pet/boat UV sheets — blocked by production geometry/consumer.
+- sky/sea bitmaps — conditional on real material/shader technique; prefer simple color/light/procedural route.
+- UI icon pack — current text controls are functional; reopen only for a binding consumer/readability need.
+- application icon/store/marketing — real eventual P3 requirement, held until release targets/brand package are explicit.
 
 ## After user approves this queue
 
-Proceed in order:
-
 ```text
-IMG-01 text contract → generate/edit → review → user approval → Notion registration
-IMG-02 text contract → generate/edit → review → user approval → Notion registration
-then update downstream handoff to READY_FOR_CODEX_IMAGE_INTEGRATION
+IMG-01 → generate/edit → GPT review → user asset approval → individual Asset Library registration
+IMG-02 → generate/edit → GPT review → user asset approval → individual Asset Library registration
+→ both active Goals IMPLEMENTATION_READY
+→ CODEX-IMG-01 → CODEX-IMG-02
+→ 540×960 runtime proof
 ```
 
 ## Evidence ceiling

--- a/docs/visual/2026-08-26-game-image-consumer-manifest.md
+++ b/docs/visual/2026-08-26-game-image-consumer-manifest.md
@@ -1,11 +1,13 @@
 # My Little Boat — Game Image Consumer Manifest
 
-Status: `CONSUMER_FIRST_ASSET_POLICY / IMAGE_GENERATION_PAUSED_UNTIL_READY`
+Status: `CONSUMER_FIRST_ASSET_POLICY / ACTIVE_GOALS_DEFINED`
 Date: 2026-08-26
+
+> Current Goal authority: `docs/visual/2026-08-26-remaining-image-goals.md`. This file owns the consumer inventory and deferred-consumer rules; it does not replace the Image Goal acceptance packets.
 
 ## Policy
 
-An image is produced only when it has a concrete Godot consumer.
+An image is produced only when it has a concrete current or approved planned game consumer.
 
 Every image asset must define:
 
@@ -20,150 +22,161 @@ validation
 
 Reference boards and explanatory sheets do not count as game-consumable assets.
 
+The approved sequence is:
+
+```text
+consumer contract
+→ Image Goal
+→ GPT image generation/editing
+→ user asset approval
+→ Notion Asset Library registration
+→ IMPLEMENTATION_READY
+→ Codex import/wiring
+→ runtime screenshot/play verification
+```
+
+Codex does not create or edit images.
+
 ## Current-main audit
 
 Current repository evidence shows:
 
-- `assets/images/` contains only its README; no production image binary is currently stored there.
-- no current `.png` reference was found in project code/scenes.
-- no current `albedo_texture` reference was found.
-- `scenes/main_menu.tscn` uses `ColorRect` for its background.
-- `scenes/album.tscn` uses `ColorRect` for its background.
-- `scenes/boat_space.tscn` uses primitive meshes and color-only `StandardMaterial3D` placeholders.
-- `scripts/decor/boat_decor_slot.gd` constructs primitive decor meshes and sets `albedo_color`; it does not load texture files.
+- `assets/images/` contains only its README; production image binary = `0`.
+- no current `.png` resource reference was observed in project code/scenes.
+- no current `albedo_texture` reference was observed.
+- `scenes/main_menu.tscn` and `scenes/album.tscn` use `ColorRect` backgrounds.
+- `scenes/game.tscn` uses color-only Environment/Ocean materials and text UI.
+- `scenes/boat_space.tscn` uses primitive meshes and color-only materials.
+- `scripts/decor/boat_decor_slot.gd` constructs primitive decor and sets `albedo_color`.
 
 Therefore:
 
 ```text
-CURRENT_RUNTIME_IMAGE_CONSUMERS = 0
+IMPLEMENTED_GAME_IMAGE_ASSETS = 0
+RUNTIME_VERIFIED_GAME_IMAGE_ASSETS = 0
+P0_AUTHORED_IMAGE_GOALS = 0
 ```
-
-Do not generate another gameplay image until a consumer contract below reaches `READY_TO_GENERATE`.
 
 ## Approved references retained, not counted as runtime assets
 
-- Visual Proof 01 — approved reference
-- Visual Proof 02 — approved reference
-- Image A — approved customization reference
-- Image B — approved time-of-day/boat atmosphere reference
-
-These can guide production, but the files themselves are not required runtime assets unless a specific consumer is later created for them.
+- Visual Proof 01 — `APPROVED / REFERENCE_ONLY`
+- Visual Proof 02 — `APPROVED / REFERENCE_ONLY`
+- Image A — `APPROVED / REFERENCE_ONLY`
+- Image B — `APPROVED / REFERENCE_ONLY`
+- older player/pet board before the dog-inclusive Image A — `SUPERSEDED`
+- planning/checklist infographics — `REFERENCE_ONLY / NOT_GAME_ASSET`
 
 `Image C / Representative Visual GDD` is cancelled as a required production image.
 
-## Candidate consumer contracts
+## Active consumer contracts
 
-### 1. Pet cushion textures
+### IMG-01 / Pet cushion runtime surface set
 
 ```yaml
-status: CONSUMER_CONTRACT_CANDIDATE
-asset_path: res://assets/images/decor/pet_cushion/
+status: IMAGE_GOAL_DEFINED_NEEDS_REVISION
+asset_path:
+  - res://assets/images/decor/pet_cushion/cushion_stripe.png
+  - res://assets/images/decor/pet_cushion/cushion_moon.png
+  - res://assets/images/decor/pet_cushion/cushion_floral.png
 consumer_item_id: pet_cushion
-consumer_target: Boat Decoration pet_cushion visual material
-intended_property: StandardMaterial3D.albedo_texture
+consumer_target: Boat Decoration PetCorner / pet_cushion visual material
+intended_property: StandardMaterial3D.albedo_texture or equivalent simple material input
 runtime_role: player-visible cushion appearance customization
-fallback: existing color-only material
+spec: 1024x1024 opaque sRGB flat surface art
+fallback: current color-only pet_cushion visual remains safe if a texture is missing
+validation: actual 540x960 runtime screenshot for all three variants after Codex integration
 ```
 
-Why first:
-- `pet_cushion` already exists as a stable decor item meaning.
-- the user explicitly approved pet cushion customization.
-- it is cosmetic and does not affect stats/rewards.
+The current user-approved rendered cushion images are **source motif references**, not direct albedo maps. Their outer cushion geometry, tufting and lighting must not be baked into the final surface files.
 
-Before generation:
-- choose minimal variant count;
-- define how the chosen texture maps to the actual cushion mesh;
-- define import size/color-space expectations;
-- ensure the consumer will actually load the file.
-
-### 2. Postcard face textures
+### IMG-02 / Postcard memory face set
 
 ```yaml
-status: CONSUMER_CONTRACT_CANDIDATE
-asset_path: res://assets/images/decor/postcard/
+status: IMAGE_GOAL_DEFINED_NEEDS_REVISION
+asset_path:
+  - res://assets/images/decor/postcard/postcard_dawn.png
+  - res://assets/images/decor/postcard/postcard_boat_bright.png
+  - res://assets/images/decor/postcard/postcard_boat_sunset.png
 consumer_item_id: postcard
-consumer_target: Boat Decoration postcard visual material
-intended_property: StandardMaterial3D.albedo_texture
-runtime_role: readable personal/memory artwork on placed postcard decor
-fallback: existing neutral color-only postcard material
+consumer_target: Boat Decoration rail/postcard front-face material
+intended_property: StandardMaterial3D.albedo_texture or equivalent face texture
+runtime_role: quiet personal/memory art visible on placed postcard decor
+spec: 1024x768 4:3 opaque sRGB normalized card-face art
+fallback: current neutral color-only postcard visual remains safe if a texture is missing
+validation: actual 540x960 normal-camera screenshot for all three variants after Codex integration
 ```
 
-Why first:
-- `postcard` already exists as a stable decor item.
-- the object is visually planar and suited to authored 2D art.
-- a small number of variants can be directly player-visible without expanding core systems.
+The current user-approved postcard renders preserve the approved compositions but must be normalized to the actual face texture. External presentation canvas/drop shadow does not belong in the runtime asset.
 
-Before generation:
-- confirm face orientation/UV mapping;
-- define 1–3 initial variants only;
-- define import size and alpha policy;
-- verify 3/4-camera readability.
+## Deferred / no current authored-image requirement
 
-## Deferred until their consumer exists
+### Main Menu background
 
-### Character / pet albedo textures
+Status: `NO_REQUIRED_AUTHORED_IMAGE`.
 
-Status: `BLOCKED_BY_PRODUCTION_MESH_AND_UV`.
+Current ColorRect is valid. Do not invent a static background consumer merely to use an image. Re-open only after a deliberate screen implementation choice, preferably checking whether live 3D/current world treatment is a better fit.
 
-Do not generate character/pet texture sheets until the actual 3D mesh and UV layout exist. The approved Image A remains reference only.
+### Album background / album photos
 
-### Boat / general decor albedo textures
+Status: `NO_AUTHORED_BACKGROUND_REQUIRED / RUNTIME_CAPTURE_FUTURE`.
 
-Status: `BLOCKED_BY_PRODUCTION_MESH_AND_UV`.
+Player photo content should ultimately come from actual runtime capture rather than authored fake voyage screenshots.
 
-If color-only materials are sufficient, skip bitmap generation entirely.
+### Character / Pet selection portraits
 
-### Sky / time-of-day images
+Status: `DERIVE_FROM_REAL_3D`.
+
+Do not create fake 2D selection portraits. Use actual production model previews/renders once those assets exist.
+
+### Character / Pet / Boat exact albedo maps
+
+Status: `BLOCKED_BY_PRODUCTION_GEOMETRY_AND_CONSUMER`.
+
+Do not pre-generate UV-specific texture sheets. If a stable bitmap material consumer is later established, open a new Image Goal with the exact geometry/material contract.
+
+### Sky / time-of-day bitmap assets
 
 Status: `CONDITIONAL`.
 
-Generate only if the Godot Environment explicitly adopts a panorama/sky texture consumer. If Dawn/Bright/Sunset/Night are implemented with colors/lights/material parameters, create no sky bitmap.
-
-Image B is a reference, not a runtime sky image.
+Use Image B as reference. Prefer color/light/simple/procedural implementation. Create panorama/sky bitmaps only if runtime technique explicitly requires them.
 
 ### Sea normal/noise maps
 
 Status: `CONDITIONAL`.
 
-Generate only if the final sea material/shader samples texture maps. Prefer no image when simple/procedural material is sufficient.
+Create only if the selected sea material actually samples texture maps and a simple/procedural route is insufficient.
 
 ### UI icons
 
-Status: `BLOCKED_BY_UI_TEXTURE_CONSUMER`.
+Status: `DEFER_NO_BINDING_CONSUMER`.
 
-Current UI is text Button/ColorRect based. Generate icons only after a concrete `TextureButton`, `TextureRect`, theme icon, or equivalent consumer is approved.
+Current text buttons are functional. Open an icon Image Goal only after a concrete button/theme consumer and player-readability need are established.
 
-Possible future meanings: Mood, Appreciation, Photo, Fishing, Decor, Interaction, Album.
+### Release / store / marketing images
 
-### Main menu / Album backgrounds
+Status: `P3_HOLD`.
 
-Status: `NO_CURRENT_CONSUMER`.
-
-Current scenes use `ColorRect`. Do not generate background images unless those screens are deliberately changed to a texture consumer.
-
-## Runtime-generated images
-
-Album/voyage photos should be produced from actual runtime capture when implemented. Do not substitute authored concept art for a player's captured voyage image.
-
-Character/pet selection thumbnails should preferably derive from actual production 3D previews/renders so the selection UI matches the model the player receives.
+Wait for platform requirements and branding lock.
 
 ## Current next action
 
 ```text
-1. Keep image generation paused.
-2. Promote one candidate consumer contract to READY_TO_GENERATE.
-3. Define exact path/spec/consumer mapping.
-4. Generate only that asset.
-5. Wire it in Godot through the product-implementation owner.
-6. Verify the exact file is loaded and visible in runtime.
-7. Only then count that image as DONE.
+1. User reviews/approves IMG-01 + IMG-02 Goal Queue.
+2. GPT creates/edits IMG-01 only after that approval.
+3. Review → user asset approval → Notion individual records → IMPLEMENTATION_READY.
+4. Repeat for IMG-02.
+5. Only then unpause CODEX-IMG-01 and CODEX-IMG-02 unless user explicitly narrows the batch.
+6. Runtime proof is required before IMPLEMENTED/RUNTIME_VERIFIED claims.
 ```
 
-Recommended first consumer batch after contract lock:
+## Evidence ceiling
 
 ```text
-PET_CUSHION_TEXTURES
-POSTCARD_TEXTURES
+ACTIVE_IMAGE_GOALS = 2
+APPROVED_REFERENCE_VISUALS = 4
+APPROVED_SOURCE_MOTIFS = 6
+IMPLEMENTATION_READY_IMAGE_ASSETS = 0
+IMPLEMENTED_IMAGE_ASSETS = 0
+RUNTIME_VERIFIED_IMAGE_ASSETS = 0
+NEW_IMAGE_GENERATION_THIS_TASK = NOT_RUN
 ```
-
-No other image batch should be generated by default.

--- a/docs/visual/2026-08-26-game-image-consumer-manifest.md
+++ b/docs/visual/2026-08-26-game-image-consumer-manifest.md
@@ -3,13 +3,13 @@
 Status: `CONSUMER_FIRST_ASSET_POLICY / ACTIVE_GOALS_DEFINED`
 Date: 2026-08-26
 
-> Current Goal authority: `docs/visual/2026-08-26-remaining-image-goals.md`. This file owns the consumer inventory and deferred-consumer rules; it does not replace the Image Goal acceptance packets.
+> Goal authority: `docs/visual/2026-08-26-remaining-image-goals.md`.
 
 ## Policy
 
 An image is produced only when it has a concrete current or approved planned game consumer.
 
-Every image asset must define:
+Every generated game asset must define:
 
 ```text
 asset_path
@@ -20,161 +20,104 @@ fallback
 validation
 ```
 
-Reference boards and explanatory sheets do not count as game-consumable assets.
-
-The approved sequence is:
+Pipeline:
 
 ```text
-consumer contract
-→ Image Goal
-→ GPT image generation/editing
-→ user asset approval
-→ Notion Asset Library registration
-→ IMPLEMENTATION_READY
-→ Codex import/wiring
-→ runtime screenshot/play verification
+consumer contract → Image Goal → GPT asset production/review → user approval
+→ Notion registration → IMPLEMENTATION_READY → Codex integration → runtime proof
 ```
 
-Codex does not create or edit images.
+Codex does not create/edit images.
 
 ## Current-main audit
 
-Current repository evidence shows:
-
-- `assets/images/` contains only its README; production image binary = `0`.
-- no current `.png` resource reference was observed in project code/scenes.
-- no current `albedo_texture` reference was observed.
-- `scenes/main_menu.tscn` and `scenes/album.tscn` use `ColorRect` backgrounds.
-- `scenes/game.tscn` uses color-only Environment/Ocean materials and text UI.
-- `scenes/boat_space.tscn` uses primitive meshes and color-only materials.
-- `scripts/decor/boat_decor_slot.gd` constructs primitive decor and sets `albedo_color`.
-
-Therefore:
+- `assets/images/` production binaries: `0`.
+- no runtime `.png`, `Texture2D`, `TextureRect` or `albedo_texture` product consumer observed.
+- Main Menu / Album = ColorRect.
+- Game Environment/Ocean = color-only material.
+- Boat/Avatar/Pet/Decor = primitive technical placeholders + color-only material.
+- Album photo content = text records, not captures.
 
 ```text
+P0_AUTHORED_IMAGE_GOALS = 0
 IMPLEMENTED_GAME_IMAGE_ASSETS = 0
 RUNTIME_VERIFIED_GAME_IMAGE_ASSETS = 0
-P0_AUTHORED_IMAGE_GOALS = 0
 ```
 
-## Approved references retained, not counted as runtime assets
+## Reference inventory
 
-- Visual Proof 01 — `APPROVED / REFERENCE_ONLY`
-- Visual Proof 02 — `APPROVED / REFERENCE_ONLY`
-- Image A — `APPROVED / REFERENCE_ONLY`
-- Image B — `APPROVED / REFERENCE_ONLY`
-- older player/pet board before the dog-inclusive Image A — `SUPERSEDED`
-- planning/checklist infographics — `REFERENCE_ONLY / NOT_GAME_ASSET`
+- Proof 01 — `APPROVED / REFERENCE_ONLY`.
+- Proof 02 — `APPROVED / REFERENCE_ONLY`.
+- Image A — `APPROVED / REFERENCE_ONLY`.
+- Image B — `APPROVED / REFERENCE_ONLY`.
+- older pre-dog player/pet board — `SUPERSEDED`.
+- planning/checklist sheets — `REFERENCE_ONLY / NOT_GAME_ASSET`.
+- Image C / Representative Visual GDD — cancelled as required deliverable.
 
-`Image C / Representative Visual GDD` is cancelled as a required production image.
-
-## Active consumer contracts
-
-### IMG-01 / Pet cushion runtime surface set
+## Active consumer contract — IMG-01 Pet Cushion
 
 ```yaml
 status: IMAGE_GOAL_DEFINED_NEEDS_REVISION
-asset_path:
+asset_paths:
   - res://assets/images/decor/pet_cushion/cushion_stripe.png
   - res://assets/images/decor/pet_cushion/cushion_moon.png
   - res://assets/images/decor/pet_cushion/cushion_floral.png
 consumer_item_id: pet_cushion
 consumer_target: Boat Decoration PetCorner / pet_cushion visual material
-intended_property: StandardMaterial3D.albedo_texture or equivalent simple material input
 runtime_role: player-visible cushion appearance customization
-spec: 1024x1024 opaque sRGB flat surface art
-fallback: current color-only pet_cushion visual remains safe if a texture is missing
-validation: actual 540x960 runtime screenshot for all three variants after Codex integration
+spec: 1024x1024 opaque sRGB flat low-frequency repeat-friendly surface art
+fallback: current neutral color-only pet_cushion
+validation: actual 540x960 runtime screenshot for all three appearances
 ```
 
-The current user-approved rendered cushion images are **source motif references**, not direct albedo maps. Their outer cushion geometry, tufting and lighting must not be baked into the final surface files.
+Current user-approved cushion renders are `REUSE_WITH_EDIT`: motif/color identity is approved, but their rendered cushion rim/tuft/depth/light cannot be used as direct albedo.
 
-### IMG-02 / Postcard memory face set
+## Active consumer contract — IMG-02 Default Postcard
 
 ```yaml
 status: IMAGE_GOAL_DEFINED_NEEDS_REVISION
-asset_path:
-  - res://assets/images/decor/postcard/postcard_dawn.png
-  - res://assets/images/decor/postcard/postcard_boat_bright.png
-  - res://assets/images/decor/postcard/postcard_boat_sunset.png
+asset_path: res://assets/images/decor/postcard/postcard_boat_bright.png
 consumer_item_id: postcard
-consumer_target: Boat Decoration rail/postcard front-face material
-intended_property: StandardMaterial3D.albedo_texture or equivalent face texture
-runtime_role: quiet personal/memory art visible on placed postcard decor
-spec: 1024x768 4:3 opaque sRGB normalized card-face art
-fallback: current neutral color-only postcard visual remains safe if a texture is missing
-validation: actual 540x960 normal-camera screenshot for all three variants after Codex integration
+consumer_target: Boat Decoration rail/postcard front face
+runtime_role: one quiet personal/memory image on the existing postcard decor
+spec: 1024x768 4:3 opaque sRGB normalized face art
+fallback: current neutral color-only postcard
+validation: actual 540x960 normal-camera screenshot
 ```
 
-The current user-approved postcard renders preserve the approved compositions but must be normalized to the actual face texture. External presentation canvas/drop shadow does not belong in the runtime asset.
+P1 deliberately uses **one default face**. It does not create a postcard variant system only to consume extra art.
+
+Approved Dawn/Sunset source compositions remain `P2 / REUSE_LATER` until a real multi-postcard consumer is approved.
 
 ## Deferred / no current authored-image requirement
 
-### Main Menu background
-
-Status: `NO_REQUIRED_AUTHORED_IMAGE`.
-
-Current ColorRect is valid. Do not invent a static background consumer merely to use an image. Re-open only after a deliberate screen implementation choice, preferably checking whether live 3D/current world treatment is a better fit.
-
-### Album background / album photos
-
-Status: `NO_AUTHORED_BACKGROUND_REQUIRED / RUNTIME_CAPTURE_FUTURE`.
-
-Player photo content should ultimately come from actual runtime capture rather than authored fake voyage screenshots.
-
-### Character / Pet selection portraits
-
-Status: `DERIVE_FROM_REAL_3D`.
-
-Do not create fake 2D selection portraits. Use actual production model previews/renders once those assets exist.
-
-### Character / Pet / Boat exact albedo maps
-
-Status: `BLOCKED_BY_PRODUCTION_GEOMETRY_AND_CONSUMER`.
-
-Do not pre-generate UV-specific texture sheets. If a stable bitmap material consumer is later established, open a new Image Goal with the exact geometry/material contract.
-
-### Sky / time-of-day bitmap assets
-
-Status: `CONDITIONAL`.
-
-Use Image B as reference. Prefer color/light/simple/procedural implementation. Create panorama/sky bitmaps only if runtime technique explicitly requires them.
-
-### Sea normal/noise maps
-
-Status: `CONDITIONAL`.
-
-Create only if the selected sea material actually samples texture maps and a simple/procedural route is insufficient.
-
-### UI icons
-
-Status: `DEFER_NO_BINDING_CONSUMER`.
-
-Current text buttons are functional. Open an icon Image Goal only after a concrete button/theme consumer and player-readability need are established.
-
-### Release / store / marketing images
-
-Status: `P3_HOLD`.
-
-Wait for platform requirements and branding lock.
+- Main Menu static background — `NO_REQUIRED_AUTHORED_IMAGE`; current ColorRect is valid.
+- Album authored background/fake photos — `REJECT_NOW`; actual photos should be runtime capture.
+- Character/Pet selection portraits — `DERIVE_FROM_REAL_3D`.
+- Character/Pet/Boat exact UV albedo — `BLOCKED_BY_PRODUCTION_GEOMETRY`.
+- Sky/time-of-day bitmaps — `CONDITIONAL`; prefer color/light/simple procedural route.
+- Sea normal/noise maps — `CONDITIONAL`; create only if selected material samples them.
+- UI icons — `DEFER_NO_BINDING_CONSUMER`.
+- App icon / store / marketing — `P3_HOLD` until release target and branding lock.
 
 ## Current next action
 
 ```text
-1. User reviews/approves IMG-01 + IMG-02 Goal Queue.
-2. GPT creates/edits IMG-01 only after that approval.
-3. Review → user asset approval → Notion individual records → IMPLEMENTATION_READY.
-4. Repeat for IMG-02.
-5. Only then unpause CODEX-IMG-01 and CODEX-IMG-02 unless user explicitly narrows the batch.
-6. Runtime proof is required before IMPLEMENTED/RUNTIME_VERIFIED claims.
+1. User reviews/approves current IMG-01 + IMG-02 queue.
+2. GPT produces/reviews IMG-01 3 files; user approves; Notion registers final assets.
+3. GPT produces/reviews IMG-02 1 file; user approves; Notion registers final asset.
+4. Both Goals reach IMPLEMENTATION_READY.
+5. CODEX-IMG-01 then CODEX-IMG-02.
+6. Runtime proof required before IMPLEMENTED/RUNTIME_VERIFIED.
 ```
 
 ## Evidence ceiling
 
 ```text
 ACTIVE_IMAGE_GOALS = 2
+ACTIVE_REQUIRED_FILES = 4
 APPROVED_REFERENCE_VISUALS = 4
-APPROVED_SOURCE_MOTIFS = 6
+APPROVED_SOURCE_IMAGES = 6
 IMPLEMENTATION_READY_IMAGE_ASSETS = 0
 IMPLEMENTED_IMAGE_ASSETS = 0
 RUNTIME_VERIFIED_IMAGE_ASSETS = 0

--- a/docs/visual/2026-08-26-remaining-image-goals.md
+++ b/docs/visual/2026-08-26-remaining-image-goals.md
@@ -9,350 +9,317 @@ Base observed main: `05d44bba978f4cff0fc94ade8e54825f5d6c80f0`
 
 Current runtime truth:
 
-- `assets/images/` contains only `README.md`; production image binaries in repository = `0`.
-- `main_menu.tscn` and `album.tscn` use `ColorRect` rather than authored background images.
-- `game.tscn` uses color-only Environment/Ocean materials.
-- `boat_space.tscn` uses primitive Boat/Avatar/Pet meshes and color-only `StandardMaterial3D`.
-- `boat_decor_slot.gd` creates primitive decor and uses `albedo_color`; no current `albedo_texture` consumer exists.
-- album photos are currently string records, not captured images.
-- open PR #19 remains unrelated/read-only and is not part of this image workstream.
-
-Therefore:
+- `assets/images/` contains only `README.md`; production image binaries = `0`.
+- no runtime `.png`, `Texture2D`, `TextureRect` or `albedo_texture` consumer was observed in current product files.
+- Main Menu and Album backgrounds are `ColorRect`.
+- Game World/Ocean use color-only materials.
+- Boat/Avatar/Pet/Decor are primitive technical placeholders with color-only materials.
+- photo/album state is text records, not actual captured images.
+- PR #19 remains unrelated `OPEN / READ_ONLY / NO_ABSORPTION`.
 
 ```text
-IMPLEMENTED_GAME_IMAGE_ASSETS = 0
-RUNTIME_VERIFIED_GAME_IMAGE_ASSETS = 0
-```
-
-## 2. Existing visual inventory
-
-| Visual | Current class | Runtime disposition | Reuse decision |
-| --- | --- | --- | --- |
-| Approved Production Visual Proof 01 | `APPROVED` | reference only | `REUSE_AS_IS` as style/material/composition reference |
-| Approved Production Visual Proof 02 | `APPROVED` | reference only | `REUSE_AS_IS` as silhouette/pet/decor reference |
-| Image A — Player + Pet Customization Board | `APPROVED` | reference only | `REUSE_AS_IS` for character/pet identity semantics |
-| Image B — Boat / Sea / Four-Time Atmosphere | `APPROVED` | reference only | `REUSE_AS_IS` for atmosphere/value hierarchy |
-| older player/pet boards before the dog-inclusive approved Image A | `SUPERSEDED` | do not implement | `REJECT` as current asset source |
-| planning/checklist infographic sheets | `REFERENCE_ONLY` | do not implement | `REJECT` as game asset |
-| cushion stripe render | `NEEDS_REVISION` | not a valid flat albedo yet | `REUSE_WITH_EDIT` |
-| cushion moon render | `NEEDS_REVISION` | not a valid flat albedo yet | `REUSE_WITH_EDIT` |
-| cushion floral render | `NEEDS_REVISION` | not a valid flat albedo yet | `REUSE_WITH_EDIT` |
-| postcard dawn render | `NEEDS_REVISION` | motif approved; file needs face-texture normalization | `REUSE_WITH_EDIT` |
-| postcard boat bright render | `NEEDS_REVISION` | motif approved; file needs face-texture normalization | `REUSE_WITH_EDIT` |
-| postcard boat sunset render | `NEEDS_REVISION` | motif approved; file needs face-texture normalization | `REUSE_WITH_EDIT` |
-
-### Why the six approved generated images are not `IMPLEMENTATION_READY`
-
-The cushion images contain the whole cushion form, seam, raised border and baked shading. Mapping them directly as `albedo_texture` would double-bake geometry/light and fight the 3D mesh.
-
-The postcard images contain a complete illustrated card presentation with border/background treatment. The illustration is reusable, but the final runtime face asset must be normalized to the actual postcard surface so a Godot material is not given presentation-space shadow/background pixels.
-
-The user approval is preserved as **design/motif approval**. Runtime assetization is an edit/normalization task, not a redesign.
-
-## 3. Existing Solution First
-
-### Current project
-
-Adopt the approved motifs and existing stable decor semantics:
-
-- `pet_cushion` item id;
-- `postcard` item id;
-- eight existing boat decor slot ids;
-- current rest-first/no-stat/no-rarity/no-cost meaning.
-
-### Base / shared material
-
-No Base-owned project-specific cushion/postcard binary is a better identity match. Reuse Base process/evidence patterns, not generic visual trade dress.
-
-### External/reference work
-
-Reuse the already approved benchmark disposition only:
-
-- `Spirit City` — attachment through avatar/personal space/companion, without XP pressure;
-- `Dordogne` — authored surface and restrained technique;
-- `SEASON` — simplification, silhouette/readability, believable light.
-
-No new benchmark is required to re-open the already-approved visual style.
-
-## 4. Alternative trade study
-
-| Route | Description | Result |
-| --- | --- | --- |
-| A | generate static backgrounds, extra icons, portraits and more concept sheets now | `REJECT` — creates images before a binding consumer and increases mismatch/rework |
-| B | assetize only planar/consumer-stable approved surfaces first | `ADOPT` — highest certainty, lowest rework, directly connected to existing decor semantics |
-| C | pre-generate UV-specific character/boat/pet textures before production geometry exists | `REJECT_NOW / DEFER` — violates consumer-first and risks unusable UV/layout assets |
-
-Recommended route: **B**.
-
-## 5. Priority result
-
-```text
+IMPLEMENTATION_READY_IMAGE_ASSETS = 0
+IMPLEMENTED_IMAGE_ASSETS = 0
+RUNTIME_VERIFIED_IMAGE_ASSETS = 0
 P0_AUTHORED_IMAGE_GOALS = 0
 ```
 
-There is no missing authored bitmap that blocks core gameplay verification today. The P0 blockers are production 3D/runtime implementation, not image generation.
+The current P0 visual blockers are production 3D/runtime work, not missing authored bitmaps.
 
-The first actionable image work is P1 vertical-slice polish on surfaces whose gameplay meaning already exists.
+## 2. Existing visual inventory / reuse
+
+| Visual | State | Runtime use | Existing Solution First |
+| --- | --- | --- | --- |
+| Visual Proof 01 | `APPROVED` | reference only | `REUSE_AS_IS` style/material/composition |
+| Visual Proof 02 | `APPROVED` | reference only | `REUSE_AS_IS` silhouette/pet/decor |
+| Image A — Player + Pet Customization | `APPROVED` | reference only | `REUSE_AS_IS` identity/customization meaning |
+| Image B — Boat/Sea/Four-Time | `APPROVED` | reference only | `REUSE_AS_IS` atmosphere/value hierarchy |
+| pre-dog player/pet board | `SUPERSEDED` | none | `REJECT` as current source |
+| planning/checklist sheets | `REFERENCE_ONLY` | none | `REJECT` as game asset |
+| 3 cushion renders | motif `APPROVED`; runtime `NEEDS_REVISION` | future pet cushion | `REUSE_WITH_EDIT` |
+| bright-boat postcard render | composition `APPROVED`; runtime `NEEDS_REVISION` | future postcard face | `REUSE_WITH_EDIT` |
+| dawn + sunset postcard renders | `APPROVED` source compositions | no current variant consumer | `REUSE_LATER / P2` |
+
+### Why the current cushion/postcard renders are not implementation-ready
+
+The cushion sources include a whole rendered cushion, seam, raised rim, depth and directional shading. Direct albedo use would double-bake geometry/light.
+
+The postcard sources include presentation-space card/canvas treatment. Their illustration is reusable, but a runtime face file must be normalized to the actual postcard surface.
+
+User approval remains valid at motif/composition level; runtime assetization is a controlled edit, not a redesign.
+
+## 3. Alternative trade study
+
+| Route | Meaning | Decision |
+| --- | --- | --- |
+| A | create static backgrounds, icon packs, fake portraits and more explanatory sheets now | `REJECT` — no binding consumer / rework risk |
+| B | assetize only approved surfaces whose gameplay meaning/consumer is already stable | `ADOPT` |
+| C | pre-generate UV-specific character/pet/boat textures before production geometry exists | `REJECT_NOW / DEFER` |
+
+Route B is the smallest path that produces real game-consumable image files without forcing new unrelated systems.
 
 ---
 
 # IMG-01 — Pet Cushion Runtime Surface Set
 
 Priority: `P1`
-Current state: `NEEDS_REVISION`
-Reuse mode: `REUSE_WITH_EDIT`
+State: `NEEDS_REVISION`
+Reuse: `REUSE_WITH_EDIT`
+Required images: `3`
 
-## 1. Player / Product Goal
+### 1. Player / Product Goal
 
-The player can make the pet's resting corner feel personally chosen while the pet remains a low-pressure resting companion. The three choices must communicate cozy preference only, never rarity, power, care obligation or monetization value.
+The pet corner should feel personally chosen through three calm cushion appearances, while the pet remains a no-obligation resting companion. Appearance choice must never imply power, rarity, care state, price or progression advantage.
 
-## 2. Actual Consumer
+### 2. Actual Consumer
 
 - Scene: `scenes/game.tscn` → `VoyageWorld/BoatSpace/BoatDecorSlots/PetCorner`
 - System: Boat Decoration
-- Stable semantic item: `pet_cushion`
-- Planned material consumer: the 3D `pet_cushion` visual material, normally through `StandardMaterial3D.albedo_texture` or an equivalent simple Godot material input selected by Codex.
-- Planned paths:
+- Stable base item: `pet_cushion`
+- Planned consumer: `pet_cushion` 3D visual material, using `StandardMaterial3D.albedo_texture` or the smallest equivalent material input selected by Codex.
+- Planned files:
   - `res://assets/images/decor/pet_cushion/cushion_stripe.png`
   - `res://assets/images/decor/pet_cushion/cushion_moon.png`
   - `res://assets/images/decor/pet_cushion/cushion_floral.png`
+- Fallback: existing neutral color-only `pet_cushion` remains usable if a texture is unavailable.
 
-The variant mechanism is implementation work. It must preserve the stable `pet_cushion` meaning rather than turning variants into new gameplay categories.
+The visual-variant state representation is Codex implementation detail. It must reuse the stable `pet_cushion` meaning rather than creating new item categories, rarity or economy.
 
-## 3. Existing References
+### 3. Existing References
 
-- Image A — pet cushion customization meaning and player/pet relationship.
-- Proof 01 / Proof 02 — matte, low-noise, hand-painted surface target.
-- approved generated cushion designs:
-  - stripe + small wave embroidery, SHA-256 `ccc05bfb09cdf26b3cdf8c834cde252dee03ab656cdd20be62b2de28116cfa99`;
-  - lavender moon + stars, SHA-256 `ff0327998969f5b8e034c887a1ec9067aefabc5f98a4238bf374204d316792a5`;
-  - vintage floral, SHA-256 `3426a4463dddcb202b5b9c43a27612cd71203130647e0ca4a7f6c76947deca58`.
+- Image A: approved pet-cushion customization meaning.
+- Proof 01/02: matte, hand-painted, low-noise surface language.
+- Stripe source SHA-256 `ccc05bfb09cdf26b3cdf8c834cde252dee03ab656cdd20be62b2de28116cfa99`.
+- Moon source SHA-256 `ff0327998969f5b8e034c887a1ec9067aefabc5f98a4238bf374204d316792a5`.
+- Floral source SHA-256 `3426a4463dddcb202b5b9c43a27612cd71203130647e0ca4a7f6c76947deca58`.
 
-Use them as **pattern/color identity references**, not as direct albedo maps.
+Use the source images for pattern/color identity only, not as direct material maps.
 
-## 4. Required Assets
+### 4. Required Assets
 
 1. `cushion_stripe.png`
-   - purpose: cream/soft-blue striped fabric with tiny wave motif;
-   - target: 1024×1024 square source;
-   - alpha: no; opaque sRGB albedo;
-   - state/variant: stripe;
-   - reuse: existing approved design with edit/regeneration.
+   - cream + soft-blue stripe; tiny wave embroidery cue;
+   - 1024×1024, opaque sRGB;
+   - flat, low-frequency, repeat-friendly surface art;
+   - no alpha required.
 2. `cushion_moon.png`
-   - purpose: muted lavender fabric with restrained moon/star stitched motifs;
-   - target: 1024×1024;
-   - alpha: no;
-   - state/variant: moon;
-   - reuse: existing approved design with edit/regeneration.
+   - muted lavender; restrained stitched moon/stars;
+   - 1024×1024, opaque sRGB;
+   - flat, low-frequency, repeat-friendly surface art.
 3. `cushion_floral.png`
-   - purpose: cream/olive low-density floral fabric;
-   - target: 1024×1024;
-   - alpha: no;
-   - state/variant: floral;
-   - reuse: existing approved design with edit/regeneration.
+   - cream/olive; sparse small botanical motifs;
+   - 1024×1024, opaque sRGB;
+   - flat, low-frequency, repeat-friendly surface art.
 
-All three must be **surface art**, not a rendered cushion object. No perspective, rim, drop shadow, tuft depth, baked directional lighting or background.
+### 5. Must Preserve
 
-## 5. Must Preserve
+- the three user-approved motif identities;
+- `HANDPAINTED_STORYBOOK_3D_DIORAMA` surface language;
+- muted/comfortable long-viewing palette;
+- pet = resting companion, not collectible mascot;
+- cosmetic-only semantics.
 
-- approved three motif identities;
-- hand-painted storybook texture;
-- low saturation / warm-cool balance;
-- quiet non-mascot pet role;
-- no gameplay/stat difference between variants.
+### 6. Must Not Introduce
 
-## 6. Must Not Introduce
+- rendered cushion silhouette/rim/tuft/depth;
+- drop shadow, perspective or directional baked lighting;
+- rarity glow/badge, premium mark, price, text/logo;
+- pet need/care indicator;
+- new pet species or gameplay rule.
 
-- rarity glow, badge, stars as rarity rating, prices or premium framing;
-- pet needs/care state;
-- new pet species;
-- brand/logo/text;
-- baked 3D cushion geometry or directional light.
+### 7. Quality Target
 
-## 7. Quality Target
+- actual material-source quality, not concept-sheet quality;
+- usable on simple current/future cushion geometry without obvious presentation-space artifacts;
+- remains distinct after aggressive reduction at the 540×960 portrait gameplay target;
+- motif density low enough not to compete with sea/horizon.
 
-- production-use albedo source, not a concept render;
-- remains readable on a small cushion at the 540×960 portrait gameplay target;
-- motif frequency low enough not to create visual noise;
-- compatible with neutral UV/triplanar/simple mapping without obvious presentation-space artifacts.
+### 8. Acceptance Criteria
 
-## 8. Acceptance Criteria
+PASS only when:
 
-- exactly three approved variants exist as separate flat source images;
-- no rendered cushion edge/shadow remains;
-- each file can plausibly feed a Godot material directly;
-- the three variants are distinguishable after strong downscale;
-- visual language matches Image A/Proofs without copying another game's trade dress;
-- file naming and path contract are stable.
+- exactly three separate flat surface files exist;
+- no rendered cushion geometry/shadow remains;
+- files can plausibly feed a Godot material directly;
+- Stripe/Moon/Floral remain identifiable at small scale;
+- file names/paths are fixed;
+- no canon or reward/economy semantics changed.
 
-## 9. Verification
+### 9. Verification
 
 ```text
-Generated
-→ Reviewed
-→ Approved
+Generated/Edited
+→ GPT Reviewed
+→ User Approved
 → Notion Registered
-→ Implementation Ready
-→ CODEX-IMG-01 Implemented
-→ Runtime Verified
+→ IMPLEMENTATION_READY
+→ CODEX-IMG-01
+→ Implemented
+→ 540×960 Runtime Screenshot
+→ RUNTIME_VERIFIED
 ```
 
 ---
 
-# IMG-02 — Postcard Memory Face Set
+# IMG-02 — Default Postcard Memory Face
 
 Priority: `P1`
-Current state: `NEEDS_REVISION`
-Reuse mode: `REUSE_WITH_EDIT`
+State: `NEEDS_REVISION`
+Reuse: `REUSE_WITH_EDIT`
+Required images: `1`
 
-## 1. Player / Product Goal
+### 1. Player / Product Goal
 
-Placed postcards should read as small, personal memory traces on the boat, reinforcing attachment without becoming a collectible scoreboard or covering the sea-first composition.
+The existing `postcard` decor should visibly carry one quiet personal memory image, adding attachment to the boat without introducing a postcard collection/variant system just to consume extra art.
 
-## 2. Actual Consumer
+### 2. Actual Consumer
 
-- Scene: `scenes/game.tscn` → Boat Decoration rail slot (`rail_accent`) / postcard visual.
+- Scene: `scenes/game.tscn` → Boat Decoration `rail_accent` postcard visual.
 - System: Boat Decoration.
-- Stable semantic item: `postcard`.
-- Planned material consumer: postcard front-face material / `albedo_texture` or equivalent.
-- Planned paths:
-  - `res://assets/images/decor/postcard/postcard_dawn.png`
-  - `res://assets/images/decor/postcard/postcard_boat_bright.png`
-  - `res://assets/images/decor/postcard/postcard_boat_sunset.png`
+- Stable base item: `postcard`.
+- Planned consumer: postcard front face via `albedo_texture` or equivalent simple face material.
+- Planned file: `res://assets/images/decor/postcard/postcard_boat_bright.png`.
+- Fallback: current neutral color-only postcard remains usable if the texture is unavailable.
 
-Variant selection remains cosmetic. Codex may implement the smallest data representation that preserves the base `postcard` semantics.
+No new postcard selector/state is required for this P1 Goal.
 
-## 3. Existing References
+### 3. Existing References
 
-- Image B — dawn/bright/sunset atmosphere and stable horizon hierarchy.
-- Proof 01 / Proof 02 — painted surface language and low visual noise.
-- approved generated postcard designs:
-  - dawn sea, SHA-256 `4aefdf55a02f0d255de21250d68f1cbb3ac478db69e2d19d15da2eb0e7a8eff9`;
-  - bright boat/sea, SHA-256 `1f0a0c9d5c658f58a55290d3a9dddeaca231630cd1158170cbc655ed6b823a3d`;
-  - sunset boat/sea, SHA-256 `23058b8390c564a330c66257ff04a1ec38e0686eaf886f09b999b10c562b9131`.
+- Image B: Bright atmosphere, stable horizon and sea-first hierarchy.
+- Proof 01/02: hand-painted low-noise surface language.
+- approved Bright Boat source SHA-256 `1f0a0c9d5c658f58a55290d3a9dddeaca231630cd1158170cbc655ed6b823a3d`.
+- Dawn source SHA-256 `4aefdf55a02f0d255de21250d68f1cbb3ac478db69e2d19d15da2eb0e7a8eff9` and Sunset source SHA-256 `23058b8390c564a330c66257ff04a1ec38e0686eaf886f09b999b10c562b9131` remain approved P2 reuse candidates only.
 
-Use composition/color as approved reference. Remove presentation-space shadow/background from the final face texture.
+### 4. Required Assets
 
-## 4. Required Assets
+1. `postcard_boat_bright.png`
+   - bright calm sea + small personal boat memory composition;
+   - 1024×768, 4:3, opaque sRGB;
+   - normalized to the card face itself;
+   - a small painted paper border may belong to the face, but no external canvas/drop shadow may remain.
 
-1. `postcard_dawn.png` — 4:3 face art, target 1024×768, opaque sRGB.
-2. `postcard_boat_bright.png` — 4:3 face art, target 1024×768, opaque sRGB.
-3. `postcard_boat_sunset.png` — 4:3 face art, target 1024×768, opaque sRGB.
+### 5. Must Preserve
 
-A small painted paper border may be part of the **postcard face itself**. External canvas/background/drop shadow may not.
+- approved bright-boat composition and calm sea identity;
+- stable horizon;
+- hand-painted storybook treatment;
+- postcard = quiet decor/memory trace, not progression reward.
 
-## 5. Must Preserve
+### 6. Must Not Introduce
 
-- stable calm horizon;
-- same-world hand-painted style;
-- Dawn/Bright/Sunset semantic identities already approved;
-- small-memory role, not progression reward.
+- external presentation background/drop shadow;
+- readable brand/logo/text;
+- rarity/collectible scoring;
+- dramatic threat weather;
+- new character, place or boat lore that becomes canon accidentally;
+- new postcard-variant system in P1.
 
-## 6. Must Not Introduce
+### 7. Quality Target
 
-- text or readable brand/logo;
-- collectible rarity symbols;
-- dramatic weather/threat;
-- new character/boat lore that becomes canon by accident;
-- external drop shadow/background baked around the card.
+- directly usable on a planar postcard face;
+- strong simple silhouette/value grouping surviving very small 3/4-camera display;
+- no high-frequency details that become noise.
 
-## 7. Quality Target
+### 8. Acceptance Criteria
 
-- directly usable on the planar postcard face;
-- main composition survives reduction to a very small object in 3/4 camera;
-- no high-frequency details that turn to noise;
-- border treatment remains visible but does not consume most of the tiny texture.
+PASS only when:
 
-## 8. Acceptance Criteria
+- one normalized 4:3 face file exists at the fixed path;
+- no external presentation canvas/shadow remains;
+- boat/sea memory is still readable after thumbnail reduction;
+- current `postcard` behavior can consume it without requiring new progression/collection state;
+- visual hierarchy remains subordinate to the boat/sea scene.
 
-- three normalized, separate 4:3 face files exist;
-- no presentation background/shadow remains outside the intended card face;
-- each is visibly different at thumbnail scale;
-- image still reads as a memory trace when small;
-- file paths and consumer meaning are fixed.
-
-## 9. Verification
+### 9. Verification
 
 ```text
-Generated
-→ Reviewed
-→ Approved
+Generated/Edited
+→ GPT Reviewed
+→ User Approved
 → Notion Registered
-→ Implementation Ready
-→ CODEX-IMG-02 Implemented
-→ Runtime Verified
+→ IMPLEMENTATION_READY
+→ CODEX-IMG-02
+→ Implemented
+→ 540×960 Runtime Screenshot
+→ RUNTIME_VERIFIED
 ```
 
 ---
 
-## 6. Deferred / not current Image Goals
+## 4. P2 / P3 and deferred image requirements
 
-### Main Menu background
+### P2 — Additional Postcard Faces
 
-Disposition: `REJECT_NOW / NO_REQUIRED_AUTHORED_IMAGE`.
+Status: `HOLD_NO_CURRENT_VARIANT_CONSUMER`.
 
-Current consumer is `ColorRect`; changing it to a static illustrated background would invent a consumer and risk showing a different visual truth from the actual 3D game. Prefer current simple background or a future live 3D scene if product implementation chooses it. Re-open only after an explicit consumer decision.
+Approved Dawn and Sunset compositions are preserved for reuse. Open a P2 Image Goal only after the product has a real reason to show more than one postcard face; do not create a selection system solely to use two extra images.
 
-### Album background
+### Main Menu static background
 
-Disposition: `REJECT_NOW`.
+Status: `REJECT_NOW / NO_REQUIRED_AUTHORED_IMAGE`.
 
-Album is currently text summary. The meaningful images should eventually be player/runtime captures, not authored replacement screenshots.
+Current ColorRect is valid. Do not invent a static-image consumer solely to increase image count. A future live 3D/menu presentation can be evaluated in implementation if needed.
 
-### Character / pet selection portraits
+### Album authored background / fake photos
 
-Disposition: `REJECT_FAKE_2D_ASSET`.
+Status: `REJECT_NOW`.
 
-Use previews derived from the actual production 3D avatar/pet so selection thumbnails match what the player receives.
+Album memories should ultimately use runtime capture rather than authored fake voyage screenshots.
 
-### Character / pet / boat UV-specific albedo
+### Character / Pet selection portraits
 
-Disposition: `BLOCKED_BY_PRODUCTION_GEOMETRY`.
+Status: `REJECT_FAKE_2D_ASSET`.
 
-Do not pre-generate exact UV sheets. If Codex later establishes a stable bitmap consumer, return to GPT with the exact mesh/UV/material contract and open a new Image Goal before final asset integration.
+Derive selection thumbnails from actual production 3D previews so the selection UI matches the asset received in game.
 
-### Sky / sea texture maps
+### Character / Pet / Boat exact UV albedo maps
 
-Disposition: `CONDITIONAL`.
+Status: `BLOCKED_BY_PRODUCTION_GEOMETRY`.
 
-Use Image B as reference. Prefer colors/lights/simple/procedural material. Generate bitmap panorama/normal/noise only if a real shader/material consumer is chosen and simple methods fail the approved runtime target.
+Do not pre-generate UV-specific sheets. Current pre-Codex asset queue deliberately avoids image files that cannot be guaranteed usable. If a later stable geometry/material contract proves a bitmap is necessary, create a new Image Goal before that asset is finalized.
+
+### Sky / Sea bitmap maps
+
+Status: `CONDITIONAL`.
+
+Use Image B as the visual reference. Prefer color/light/simple/procedural material. Open a new Image Goal only if the selected runtime technique explicitly needs panorama/normal/noise maps.
 
 ### UI icon pack
 
-Disposition: `DEFER / NOT_REQUIRED_NOW`.
+Status: `DEFER_NO_BINDING_CONSUMER`.
 
-Current text buttons are functional. Icon+text is a possible future polish route, but generating icons now would create work before a binding UI consumer and is not required for vertical-slice validation.
+Current text controls are functional. Create icons only if an actual icon consumer and readability/polish requirement are established.
 
-### App / Store / marketing art
+### App icon / Store / Marketing
 
-Disposition: `P3 / HOLD`.
+Priority: `P3 / HOLD`.
 
-Do not produce until release platform/store requirements and branding lock are explicit.
+An application icon is a real eventual release asset, and platform/store art may also be required, but exact platform/branding requirements are not locked. Re-open as a P3 Image Goal when release targets and brand package are explicit; do not pre-empt P1 runtime validation.
 
-## 7. Codex Integration Queue
+## 5. Codex Integration Queue
 
-After each Image Goal becomes `IMPLEMENTATION_READY`, use the matching integration goal in `docs/handoffs/2026-08-26-image-codex-integration-goals.md`.
-
-Order:
+Codex instructions are in `docs/handoffs/2026-08-26-image-codex-integration-goals.md`.
 
 ```text
-IMG-01 → CODEX-IMG-01
-IMG-02 → CODEX-IMG-02
-then runtime screenshot / mobile portrait verification
+IMG-01 (3 files) → CODEX-IMG-01
+IMG-02 (1 file) → CODEX-IMG-02
+→ 540×960 runtime screenshot/play verification
+→ GPT final review
 ```
 
-Godot work remains paused until the user has reviewed/approved this queue and GPT has finished the active image assets.
+Codex remains paused until the user approves this Goal Queue and GPT completes/gets approval/Notion registration for the active files.
 
-## 8. Evidence ceiling
+## 6. Evidence ceiling
 
 ```text
-IMAGE_GOAL_QUEUE = PLANNED
+IMAGE_GOAL_QUEUE = READY_FOR_USER_REVIEW
 NEW_IMAGE_GENERATION_THIS_TASK = NOT_RUN
 APPROVED_REFERENCE_VISUALS = 4
-APPROVED_MOTIF_SOURCE_IMAGES = 6
+APPROVED_SOURCE_IMAGES = 6
+ACTIVE_P1_IMAGE_GOALS = 2
+ACTIVE_P1_REQUIRED_FILES = 4
+P0_AUTHORED_IMAGE_GOALS = 0
 IMPLEMENTATION_READY_IMAGE_ASSETS = 0
 IMPLEMENTED_IMAGE_ASSETS = 0
 RUNTIME_VERIFIED_IMAGE_ASSETS = 0
-P0_AUTHORED_IMAGE_GOALS = 0
-ACTIVE_P1_IMAGE_GOALS = 2
 ```

--- a/docs/visual/2026-08-26-remaining-image-goals.md
+++ b/docs/visual/2026-08-26-remaining-image-goals.md
@@ -1,0 +1,358 @@
+# My Little Boat — Remaining Image Goals
+
+Status: `GOAL_QUEUE_READY_FOR_USER_REVIEW / NO_NEW_IMAGE_GENERATION_THIS_TASK`
+Date: 2026-08-26
+Baseline main: `d4d5e57027e1c83d1ae3504fce484fd4a11d8015`
+Base observed main: `05d44bba978f4cff0fc94ade8e54825f5d6c80f0`
+
+## 1. Current-state reconstruction
+
+Current runtime truth:
+
+- `assets/images/` contains only `README.md`; production image binaries in repository = `0`.
+- `main_menu.tscn` and `album.tscn` use `ColorRect` rather than authored background images.
+- `game.tscn` uses color-only Environment/Ocean materials.
+- `boat_space.tscn` uses primitive Boat/Avatar/Pet meshes and color-only `StandardMaterial3D`.
+- `boat_decor_slot.gd` creates primitive decor and uses `albedo_color`; no current `albedo_texture` consumer exists.
+- album photos are currently string records, not captured images.
+- open PR #19 remains unrelated/read-only and is not part of this image workstream.
+
+Therefore:
+
+```text
+IMPLEMENTED_GAME_IMAGE_ASSETS = 0
+RUNTIME_VERIFIED_GAME_IMAGE_ASSETS = 0
+```
+
+## 2. Existing visual inventory
+
+| Visual | Current class | Runtime disposition | Reuse decision |
+| --- | --- | --- | --- |
+| Approved Production Visual Proof 01 | `APPROVED` | reference only | `REUSE_AS_IS` as style/material/composition reference |
+| Approved Production Visual Proof 02 | `APPROVED` | reference only | `REUSE_AS_IS` as silhouette/pet/decor reference |
+| Image A — Player + Pet Customization Board | `APPROVED` | reference only | `REUSE_AS_IS` for character/pet identity semantics |
+| Image B — Boat / Sea / Four-Time Atmosphere | `APPROVED` | reference only | `REUSE_AS_IS` for atmosphere/value hierarchy |
+| older player/pet boards before the dog-inclusive approved Image A | `SUPERSEDED` | do not implement | `REJECT` as current asset source |
+| planning/checklist infographic sheets | `REFERENCE_ONLY` | do not implement | `REJECT` as game asset |
+| cushion stripe render | `NEEDS_REVISION` | not a valid flat albedo yet | `REUSE_WITH_EDIT` |
+| cushion moon render | `NEEDS_REVISION` | not a valid flat albedo yet | `REUSE_WITH_EDIT` |
+| cushion floral render | `NEEDS_REVISION` | not a valid flat albedo yet | `REUSE_WITH_EDIT` |
+| postcard dawn render | `NEEDS_REVISION` | motif approved; file needs face-texture normalization | `REUSE_WITH_EDIT` |
+| postcard boat bright render | `NEEDS_REVISION` | motif approved; file needs face-texture normalization | `REUSE_WITH_EDIT` |
+| postcard boat sunset render | `NEEDS_REVISION` | motif approved; file needs face-texture normalization | `REUSE_WITH_EDIT` |
+
+### Why the six approved generated images are not `IMPLEMENTATION_READY`
+
+The cushion images contain the whole cushion form, seam, raised border and baked shading. Mapping them directly as `albedo_texture` would double-bake geometry/light and fight the 3D mesh.
+
+The postcard images contain a complete illustrated card presentation with border/background treatment. The illustration is reusable, but the final runtime face asset must be normalized to the actual postcard surface so a Godot material is not given presentation-space shadow/background pixels.
+
+The user approval is preserved as **design/motif approval**. Runtime assetization is an edit/normalization task, not a redesign.
+
+## 3. Existing Solution First
+
+### Current project
+
+Adopt the approved motifs and existing stable decor semantics:
+
+- `pet_cushion` item id;
+- `postcard` item id;
+- eight existing boat decor slot ids;
+- current rest-first/no-stat/no-rarity/no-cost meaning.
+
+### Base / shared material
+
+No Base-owned project-specific cushion/postcard binary is a better identity match. Reuse Base process/evidence patterns, not generic visual trade dress.
+
+### External/reference work
+
+Reuse the already approved benchmark disposition only:
+
+- `Spirit City` — attachment through avatar/personal space/companion, without XP pressure;
+- `Dordogne` — authored surface and restrained technique;
+- `SEASON` — simplification, silhouette/readability, believable light.
+
+No new benchmark is required to re-open the already-approved visual style.
+
+## 4. Alternative trade study
+
+| Route | Description | Result |
+| --- | --- | --- |
+| A | generate static backgrounds, extra icons, portraits and more concept sheets now | `REJECT` — creates images before a binding consumer and increases mismatch/rework |
+| B | assetize only planar/consumer-stable approved surfaces first | `ADOPT` — highest certainty, lowest rework, directly connected to existing decor semantics |
+| C | pre-generate UV-specific character/boat/pet textures before production geometry exists | `REJECT_NOW / DEFER` — violates consumer-first and risks unusable UV/layout assets |
+
+Recommended route: **B**.
+
+## 5. Priority result
+
+```text
+P0_AUTHORED_IMAGE_GOALS = 0
+```
+
+There is no missing authored bitmap that blocks core gameplay verification today. The P0 blockers are production 3D/runtime implementation, not image generation.
+
+The first actionable image work is P1 vertical-slice polish on surfaces whose gameplay meaning already exists.
+
+---
+
+# IMG-01 — Pet Cushion Runtime Surface Set
+
+Priority: `P1`
+Current state: `NEEDS_REVISION`
+Reuse mode: `REUSE_WITH_EDIT`
+
+## 1. Player / Product Goal
+
+The player can make the pet's resting corner feel personally chosen while the pet remains a low-pressure resting companion. The three choices must communicate cozy preference only, never rarity, power, care obligation or monetization value.
+
+## 2. Actual Consumer
+
+- Scene: `scenes/game.tscn` → `VoyageWorld/BoatSpace/BoatDecorSlots/PetCorner`
+- System: Boat Decoration
+- Stable semantic item: `pet_cushion`
+- Planned material consumer: the 3D `pet_cushion` visual material, normally through `StandardMaterial3D.albedo_texture` or an equivalent simple Godot material input selected by Codex.
+- Planned paths:
+  - `res://assets/images/decor/pet_cushion/cushion_stripe.png`
+  - `res://assets/images/decor/pet_cushion/cushion_moon.png`
+  - `res://assets/images/decor/pet_cushion/cushion_floral.png`
+
+The variant mechanism is implementation work. It must preserve the stable `pet_cushion` meaning rather than turning variants into new gameplay categories.
+
+## 3. Existing References
+
+- Image A — pet cushion customization meaning and player/pet relationship.
+- Proof 01 / Proof 02 — matte, low-noise, hand-painted surface target.
+- approved generated cushion designs:
+  - stripe + small wave embroidery, SHA-256 `ccc05bfb09cdf26b3cdf8c834cde252dee03ab656cdd20be62b2de28116cfa99`;
+  - lavender moon + stars, SHA-256 `ff0327998969f5b8e034c887a1ec9067aefabc5f98a4238bf374204d316792a5`;
+  - vintage floral, SHA-256 `3426a4463dddcb202b5b9c43a27612cd71203130647e0ca4a7f6c76947deca58`.
+
+Use them as **pattern/color identity references**, not as direct albedo maps.
+
+## 4. Required Assets
+
+1. `cushion_stripe.png`
+   - purpose: cream/soft-blue striped fabric with tiny wave motif;
+   - target: 1024×1024 square source;
+   - alpha: no; opaque sRGB albedo;
+   - state/variant: stripe;
+   - reuse: existing approved design with edit/regeneration.
+2. `cushion_moon.png`
+   - purpose: muted lavender fabric with restrained moon/star stitched motifs;
+   - target: 1024×1024;
+   - alpha: no;
+   - state/variant: moon;
+   - reuse: existing approved design with edit/regeneration.
+3. `cushion_floral.png`
+   - purpose: cream/olive low-density floral fabric;
+   - target: 1024×1024;
+   - alpha: no;
+   - state/variant: floral;
+   - reuse: existing approved design with edit/regeneration.
+
+All three must be **surface art**, not a rendered cushion object. No perspective, rim, drop shadow, tuft depth, baked directional lighting or background.
+
+## 5. Must Preserve
+
+- approved three motif identities;
+- hand-painted storybook texture;
+- low saturation / warm-cool balance;
+- quiet non-mascot pet role;
+- no gameplay/stat difference between variants.
+
+## 6. Must Not Introduce
+
+- rarity glow, badge, stars as rarity rating, prices or premium framing;
+- pet needs/care state;
+- new pet species;
+- brand/logo/text;
+- baked 3D cushion geometry or directional light.
+
+## 7. Quality Target
+
+- production-use albedo source, not a concept render;
+- remains readable on a small cushion at the 540×960 portrait gameplay target;
+- motif frequency low enough not to create visual noise;
+- compatible with neutral UV/triplanar/simple mapping without obvious presentation-space artifacts.
+
+## 8. Acceptance Criteria
+
+- exactly three approved variants exist as separate flat source images;
+- no rendered cushion edge/shadow remains;
+- each file can plausibly feed a Godot material directly;
+- the three variants are distinguishable after strong downscale;
+- visual language matches Image A/Proofs without copying another game's trade dress;
+- file naming and path contract are stable.
+
+## 9. Verification
+
+```text
+Generated
+→ Reviewed
+→ Approved
+→ Notion Registered
+→ Implementation Ready
+→ CODEX-IMG-01 Implemented
+→ Runtime Verified
+```
+
+---
+
+# IMG-02 — Postcard Memory Face Set
+
+Priority: `P1`
+Current state: `NEEDS_REVISION`
+Reuse mode: `REUSE_WITH_EDIT`
+
+## 1. Player / Product Goal
+
+Placed postcards should read as small, personal memory traces on the boat, reinforcing attachment without becoming a collectible scoreboard or covering the sea-first composition.
+
+## 2. Actual Consumer
+
+- Scene: `scenes/game.tscn` → Boat Decoration rail slot (`rail_accent`) / postcard visual.
+- System: Boat Decoration.
+- Stable semantic item: `postcard`.
+- Planned material consumer: postcard front-face material / `albedo_texture` or equivalent.
+- Planned paths:
+  - `res://assets/images/decor/postcard/postcard_dawn.png`
+  - `res://assets/images/decor/postcard/postcard_boat_bright.png`
+  - `res://assets/images/decor/postcard/postcard_boat_sunset.png`
+
+Variant selection remains cosmetic. Codex may implement the smallest data representation that preserves the base `postcard` semantics.
+
+## 3. Existing References
+
+- Image B — dawn/bright/sunset atmosphere and stable horizon hierarchy.
+- Proof 01 / Proof 02 — painted surface language and low visual noise.
+- approved generated postcard designs:
+  - dawn sea, SHA-256 `4aefdf55a02f0d255de21250d68f1cbb3ac478db69e2d19d15da2eb0e7a8eff9`;
+  - bright boat/sea, SHA-256 `1f0a0c9d5c658f58a55290d3a9dddeaca231630cd1158170cbc655ed6b823a3d`;
+  - sunset boat/sea, SHA-256 `23058b8390c564a330c66257ff04a1ec38e0686eaf886f09b999b10c562b9131`.
+
+Use composition/color as approved reference. Remove presentation-space shadow/background from the final face texture.
+
+## 4. Required Assets
+
+1. `postcard_dawn.png` — 4:3 face art, target 1024×768, opaque sRGB.
+2. `postcard_boat_bright.png` — 4:3 face art, target 1024×768, opaque sRGB.
+3. `postcard_boat_sunset.png` — 4:3 face art, target 1024×768, opaque sRGB.
+
+A small painted paper border may be part of the **postcard face itself**. External canvas/background/drop shadow may not.
+
+## 5. Must Preserve
+
+- stable calm horizon;
+- same-world hand-painted style;
+- Dawn/Bright/Sunset semantic identities already approved;
+- small-memory role, not progression reward.
+
+## 6. Must Not Introduce
+
+- text or readable brand/logo;
+- collectible rarity symbols;
+- dramatic weather/threat;
+- new character/boat lore that becomes canon by accident;
+- external drop shadow/background baked around the card.
+
+## 7. Quality Target
+
+- directly usable on the planar postcard face;
+- main composition survives reduction to a very small object in 3/4 camera;
+- no high-frequency details that turn to noise;
+- border treatment remains visible but does not consume most of the tiny texture.
+
+## 8. Acceptance Criteria
+
+- three normalized, separate 4:3 face files exist;
+- no presentation background/shadow remains outside the intended card face;
+- each is visibly different at thumbnail scale;
+- image still reads as a memory trace when small;
+- file paths and consumer meaning are fixed.
+
+## 9. Verification
+
+```text
+Generated
+→ Reviewed
+→ Approved
+→ Notion Registered
+→ Implementation Ready
+→ CODEX-IMG-02 Implemented
+→ Runtime Verified
+```
+
+---
+
+## 6. Deferred / not current Image Goals
+
+### Main Menu background
+
+Disposition: `REJECT_NOW / NO_REQUIRED_AUTHORED_IMAGE`.
+
+Current consumer is `ColorRect`; changing it to a static illustrated background would invent a consumer and risk showing a different visual truth from the actual 3D game. Prefer current simple background or a future live 3D scene if product implementation chooses it. Re-open only after an explicit consumer decision.
+
+### Album background
+
+Disposition: `REJECT_NOW`.
+
+Album is currently text summary. The meaningful images should eventually be player/runtime captures, not authored replacement screenshots.
+
+### Character / pet selection portraits
+
+Disposition: `REJECT_FAKE_2D_ASSET`.
+
+Use previews derived from the actual production 3D avatar/pet so selection thumbnails match what the player receives.
+
+### Character / pet / boat UV-specific albedo
+
+Disposition: `BLOCKED_BY_PRODUCTION_GEOMETRY`.
+
+Do not pre-generate exact UV sheets. If Codex later establishes a stable bitmap consumer, return to GPT with the exact mesh/UV/material contract and open a new Image Goal before final asset integration.
+
+### Sky / sea texture maps
+
+Disposition: `CONDITIONAL`.
+
+Use Image B as reference. Prefer colors/lights/simple/procedural material. Generate bitmap panorama/normal/noise only if a real shader/material consumer is chosen and simple methods fail the approved runtime target.
+
+### UI icon pack
+
+Disposition: `DEFER / NOT_REQUIRED_NOW`.
+
+Current text buttons are functional. Icon+text is a possible future polish route, but generating icons now would create work before a binding UI consumer and is not required for vertical-slice validation.
+
+### App / Store / marketing art
+
+Disposition: `P3 / HOLD`.
+
+Do not produce until release platform/store requirements and branding lock are explicit.
+
+## 7. Codex Integration Queue
+
+After each Image Goal becomes `IMPLEMENTATION_READY`, use the matching integration goal in `docs/handoffs/2026-08-26-image-codex-integration-goals.md`.
+
+Order:
+
+```text
+IMG-01 → CODEX-IMG-01
+IMG-02 → CODEX-IMG-02
+then runtime screenshot / mobile portrait verification
+```
+
+Godot work remains paused until the user has reviewed/approved this queue and GPT has finished the active image assets.
+
+## 8. Evidence ceiling
+
+```text
+IMAGE_GOAL_QUEUE = PLANNED
+NEW_IMAGE_GENERATION_THIS_TASK = NOT_RUN
+APPROVED_REFERENCE_VISUALS = 4
+APPROVED_MOTIF_SOURCE_IMAGES = 6
+IMPLEMENTATION_READY_IMAGE_ASSETS = 0
+IMPLEMENTED_IMAGE_ASSETS = 0
+RUNTIME_VERIFIED_IMAGE_ASSETS = 0
+P0_AUTHORED_IMAGE_GOALS = 0
+ACTIVE_P1_IMAGE_GOALS = 2
+```


### PR DESCRIPTION
## Purpose
Fresh-audit the current project and convert remaining visual work into game-consumable Image Goals before Codex implementation.

## Current result
- P0 authored image goals: 0
- active P1 Image Goals: 2
- active P1 required final files: 4
  - IMG-01 Pet Cushion Runtime Surface Set: 3 flat surface assets
  - IMG-02 Default Postcard Memory Face: 1 Bright Boat face asset
- approved reference visuals: 4 (Proof 01/02, Image A/B), reference-only
- approved generated source images: 6, but current runtime state is NEEDS_REVISION / P2 reuse as applicable
- implementation-ready / implemented / runtime-verified images: 0

## Key adversarial correction
Initial draft would have implemented 3 postcard faces at P1. That was rejected as overproduction because current product has a single `postcard` item and no approved variant consumer. P1 now uses one default Bright Boat face; Dawn/Sunset stay approved P2 reuse candidates.

## Added
- `docs/visual/2026-08-26-remaining-image-goals.md`
- `docs/handoffs/2026-08-26-image-codex-integration-goals.md`

## Updated
- current planning visual router
- paused Godot router
- game image consumer manifest
- project reuse handoff

## Scope boundary
- docs/JSON only; no Scene/Resource/GDScript/image binary changes
- no new image generation in this task
- no Codex product implementation
- PR #19 remains OPEN / READ_ONLY / NO_ABSORPTION

## Review
After the postcard-scope correction, six clean whole-state loops covered omission, excess, reuse, canon conflict, Godot feasibility and player-experience value. Notion Blueprint/Checklist/Home/Plan/Handoff and source-asset records are aligned with the same queue.

## Evidence ceiling
`GOAL_QUEUE_READY_FOR_USER_REVIEW`; `IMPLEMENTATION_READY=0`; `IMPLEMENTED=0`; `RUNTIME_VERIFIED=0`; `CODEX=HOLD`.