### PR TITLE
Update merged runtime visual handoff

### DIFF
--- a/docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
+++ b/docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
@@ -153,11 +153,13 @@ IDENTITY_AUTOMATED_CONTRACTS = PASS
 IDENTITY_RUNTIME_CAPTURE = PASS
 IDENTITY_REAL_DEVICE_MOBILE_QA = DEFERRED
 REAL_DEVICE_TOUCH_QA = NOT_RUN
-FOUR_TIME_ATMOSPHERE = IMPLEMENTED_CURRENT_TASK_PR
+FOUR_TIME_ATMOSPHERE = MERGED_MAIN
 FOUR_TIME_ATMOSPHERE_AUTOMATED = PASS
 FOUR_TIME_RUNTIME_CAPTURE = PASS
 FOUR_TIME_REAL_DEVICE_MOBILE_QA = DEFERRED
 FOUR_TIME_HUMAN_COMFORT_REVIEW = NOT_RUN
+FINAL_COMPOSITE_DECOR = MERGED_MAIN
+FINAL_COMPOSITE_DECOR_RUNTIME_CAPTURE = PASS
 ```
 
 ## Current implementation packet
@@ -174,4 +176,4 @@ FOUR_TIME_HUMAN_COMFORT_REVIEW = NOT_RUN
 - `RestingSoundscape` now owns a 16-second stereo authored `OceanBed` runtime candidate at a conservative -18 dB. It preserves the wave-first layer priority and does not alter voyage, reward, camera, or social state. Automated loop wiring passes; human headset/speaker/mobile listening remains `NOT_RUN`.
 - Runtime identity selection is local-first: the main-menu `내 모습과 동반자` panel stores one approved player ID and one pet ID only in `user://identity_profile_v1.cfg`. C knit + dog preserves `FinalDioramaCard` unchanged; all other pairs use the shared boat/sea pass plus exactly one selected player card and one selected pet card. Five new 1024×1024 transparent runtime cards are individually registered in Notion Asset Library with SHA-256/provenance/durable repo locators. Normal and Appreciation GPU runtime captures for C+dog and B+otter are stored at `docs/evidence/2026-08-27-runtime-identity-selection/`. User mobile touch QA remains deferred.
 - The four-time atmosphere layer is a process-lifetime pre-voyage choice only: Dawn / Bright / Sunset / Night apply the approved restrained environment, key-light, and shared backdrop modulation to the same scene. Bright preserves the approved Bright sea art; no image binary, map, shader, audio, timer, reward, identity, decor, social, or postcard-variant behavior was added. Eight OpenGL 540×960 Normal/Appreciation captures and hashes are at `docs/evidence/2026-08-27-four-time-atmosphere/`. Human comfort and real-device mobile QA remain deferred.
-- Current-task correction: the C+dog final composite now hides only its detached `pet_corner` and `rail_accent` technical meshes, then renders the selected approved cushion surface and default postcard as flat storybook overlays. Four-time captures now isolate test decor/identity state and fail before capture if required imported textures are unavailable. The focused contracts and a 540×960 floral-cushion/postcard capture are at `docs/evidence/2026-08-27-final-composite-decor/`. Current-task PR is pending; human/mobile QA remains deferred.
+- Final-composite correction: the C+dog final composite hides only its detached `pet_corner` and `rail_accent` technical meshes, then renders the selected approved cushion surface and default postcard as flat storybook overlays. Four-time captures isolate test decor/identity state and fail before capture if required imported textures are unavailable. The focused contracts and a 540×960 floral-cushion/postcard capture are at `docs/evidence/2026-08-27-final-composite-decor/`. This correction merged to `main` through PR #48 at merge commit `eb84a86c219cdff696a2209446e282a6634302d3`; human/mobile QA remains deferred.


### PR DESCRIPTION
Updates the current implementation handoff to reflect merged PR #48 and its verified final-composite runtime evidence. Documentation only. PR #19 remains untouched.