### PR TITLE
Reconcile current main documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,13 +221,13 @@ headless project import
 
 ## 다음 구현 순서
 
-현재 completed `main`의 다음 mainline은 승인된 그림체를 실제 게임 화면으로 옮기는 **First Production Visual Slice**입니다.
+현재 completed `main`은 승인된 그림체를 C+강아지 최종 2.5D 화면, 로컬 외형 선택, 방석·엽서 표면, 네 시간대 분위기로 이미 통합했습니다. 새 mainline은 이 결과를 다시 만드는 일이 아니라 별도 승인된 다음 Product Slice입니다.
 
-1. **Local cosmetic identity selection** — 승인된 A/B/C 플레이어 외형과 고양이/토끼/수달/강아지 동반자를 `내 모습과 동반자`에서 로컬 선택할 수 있습니다. C+강아지는 기존 최종 합성을 보존하고, 다른 조합은 공용 보트·바다 위에 선택 카드 한 쌍을 표시합니다. 540×960 Normal/Appreciation runtime capture와 자동 계약 증거가 있습니다. 실제 기기 터치 검증은 보류입니다.
-2. **Human visual validation** — 현재 사용자 결정 게이트. 540×960에서 30초/5분, Normal/Appreciation, bob/idle motion을 보고 `CALM / EMPTY / NOISY`, sea-first hierarchy, visual fatigue를 판단합니다. 실제 기기 터치 검증은 사용자의 요청에 따라 뒤로 미룹니다.
+1. **현재 런타임 결과 유지** — C+강아지 기본 합성, A/B/C 플레이어·4종 펫의 로컬 외형 선택, 방석 3종, Bright Boat 엽서, 네 시간대 분위기는 자동 계약·540×960 런타임 증거와 함께 `main`에 있습니다. 실제 기기 터치 검증은 보류입니다.
+2. **Human visual validation** — 30초/5분의 실제 편안함, `CALM / EMPTY / NOISY`, sea-first hierarchy, visual fatigue는 아직 사람 검증이 필요하지만 사용자의 지시에 따라 보류합니다.
 3. **PR #19 Social Fake Backend** — 별도 독립 workstream으로 OPEN / READ_ONLY / NO ABSORPTION입니다. 현재 visual workstream에서 rebase·merge·수정하지 않으며, social 작업을 명시적으로 재개할 때 latest `main`과 다시 reconcile합니다.
 4. **Supabase/Auth/RLS/Moderation/Real Delayed Bottle** — Social Fake 계약이 current main에 안전하게 정합된 뒤 별도 보안·계정·release gate로 진행합니다.
-5. **Production audio / final avatar·pet·boat·decor assets** — First Production Visual Slice와 four-time atmosphere의 runtime evidence를 보고 제작 순서를 다시 계산합니다.
+5. **새 Product Slice** — 기능·asset·backend 추가는 concrete consumer와 별도 승인된 범위가 생긴 뒤 시작합니다. 이미 완료된 시각 통합을 이유 없이 다시 만들지 않습니다.
 
 현재 Godot 제품 구현의 **첫 진입점**:
 

--- a/docs/GODOT_MVP_ROADMAP.md
+++ b/docs/GODOT_MVP_ROADMAP.md
@@ -78,8 +78,8 @@ VISIBLE_AVATAR_PLACEHOLDER = PASS
 APPRECIATION_CAMERA = PASS
 APPRECIATION_INPUT_ISOLATION = PASS
 HUMAN_DIORAMA_COMFORT = NOT_RUN
-FINAL_AVATAR_ART = NOT_INTEGRATED
-REAL_MOBILE_CAMERA_INPUT = NOT_RUN
+FINAL_AVATAR_ART = USER_APPROVED_NOTION_REGISTERED_LOCATOR_PASS
+REAL_MOBILE_CAMERA_INPUT = DEFERRED_BY_USER
 ```
 
 ## 9단계: Local Boat Decoration + Low-pressure Interactable — 기술 구현 완료 / Human mobile QA 전
@@ -118,8 +118,8 @@ pet_cushion
 - invalid placement는 state mutation을 만들지 않는다.
 - replace/clear는 비용·손실 없음.
 - stats / rarity / price / currency / gacha / fill bonus / daily-shop pressure 없음.
-- `GameState.boat_decor`는 `slot_id -> item_id`만 저장한다.
-- Scene 전환과 새 항해에는 유지되지만 app restart persistence는 아직 없다.
+- `GameState.boat_decor`는 `slot_id -> item_id`를, 순수 외형 선택은 별도 appearance 상태를 저장한다.
+- Scene 전환·새 항해·앱 재시작 뒤에도 로컬 persistence로 유지된다.
 
 ### 9.3 Low-pressure Interactable
 
@@ -159,28 +159,27 @@ FINAL_DECOR_ART = NOT_INTEGRATED
 APP_RESTART_DECOR_PERSISTENCE = AUTOMATED_LOCAL_RESTORE_PASS
 ```
 
-## 10단계 진입 전 Current Priority Overlay · 2026-08-26
+## 10단계 진입 전 Visual Runtime Integration · 완료
 
-8월 25일 hand-painted visual canon/approved proof closeout 이후, completed `main`에서 가장 큰 증거 공백은 **승인된 visual direction과 실제 primitive runtime 사이**입니다. 따라서 현재 mainline next work는 아래 bounded proof입니다.
+승인된 visual direction과 실제 primitive runtime 사이의 증거 공백은 First Production Visual Slice, C+dog final 2.5D route, identity selection, four-time atmosphere, and final-composite decor correction으로 해소했습니다. 현재 mainline은 이 결과를 재구현하지 않고, 별도 승인된 새 product slice만 시작합니다.
 
-### First Production Visual Slice — Runtime capture + technical validation complete / Human review pending
+### Visual Runtime Result — Runtime capture + technical validation complete / Human/mobile review deferred
 
 ```text
 HANDPAINTED_STORYBOOK_3D_DIORAMA approved canon
 → actual game.tscn / BoatSpace bounded visual study
 → 540x960 Normal + Appreciation runtime capture
 → technical regression
-→ 30s / 5m Human visual review (current gate)
+→ user-approved C+dog 2.5D route + identity/decor/time integration
+→ Human/mobile comfort review deferred by user
 ```
 
 범위:
 
-- neutral player visual study. 최종 identity canonization 금지.
-- non-species resting companion treatment. 최종 pet species canonization 금지.
-- existing boat material/shape pass.
-- existing dynamic decor rendering pass + small cluster through current decor system.
-- existing sea/sky/light treatment.
-- custom watercolor shader, broad asset replacement, four-state time behavior는 이번 Slice에서 제외.
+- user-approved C knit/long-hair + dog default route preserved.
+- local cosmetic player/pet selection and approved decor surface/postcard integration complete.
+- existing boat/sea pass and controlled four-time atmosphere preserve the same place/composition.
+- broad texture-sheet, icon-pack, and postcard-variant production remain deferred without a consumer.
 
 현재 실제 Godot 제품 구현의 **첫 진입점**:
 
@@ -286,7 +285,7 @@ Social Fake 계약이 future current main에 안전하게 정합된 뒤 실제 b
 - delivery evidence
 - backend 장애 시 local rest/voyage/decor 정상 유지
 
-## 14단계: Production Resting Assets — First Production Visual Slice 증거 뒤 재계산
+## 14단계: Production Resting Assets — core runtime visual assets complete / subjective QA deferred
 
 ### Audio
 
@@ -297,10 +296,10 @@ Social Fake 계약이 future current main에 안전하게 정합된 뒤 실제 b
 
 ### Visual
 
-- First Production Visual Slice 결과를 기준으로 final asset pipeline 결정
-- four-state `새벽 / 밝음 / 해질녘 / 밤` atmosphere layer는 별도 bounded Slice로 구현. 같은 보트/바다/수평선의 출항 전 선택형 톤이며, 자동 day cycle·새 맵·이미지 variant·보상 변화는 없음. 자동 계약과 540×960 Normal/Appreciation capture는 PASS, real-device/Human comfort QA는 DEFERRED/NOT_RUN.
-- 승인된 player identity / pet species의 로컬 선택·보존은 구현됨. 임의 편집·unlock·progression은 보류.
-- representative final decor / boat / sea assets는 runtime proof 뒤 제작
+- approved final C+dog boat/sea route, player/pet selection cards, cushion surfaces, and Bright Boat postcard are integrated and runtime-verified.
+- four-state `새벽 / 밝음 / 해질녘 / 밤` atmosphere is implemented as a pre-voyage tone choice. It adds no day cycle, map, image variant system, or reward change; automated contracts and 540×960 Normal/Appreciation captures pass.
+- approved player identity / pet species remain local cosmetic selection only. Arbitrary editing, unlocks, and progression remain deferred.
+- Human/mobile comfort, touch, and audio listening remain deferred or `NOT_RUN`; they are evidence gaps, not authorization for speculative asset production.
 
 이미지 제작은 concrete runtime consumer가 있을 때만 진행하며, 사용자가 위임한 범위에서는 Codex가 검수·로컬 저장·Notion 정본 등록을 자동으로 수행합니다.
 

--- a/docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
+++ b/docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
@@ -7,7 +7,7 @@
 ```yaml
 project: MY_LITTLE_BOAT
 mode: CODEX_GODOT_PRODUCT_IMPLEMENTATION_HANDOFF
-status: CODEX_IMAGE_INTEGRATION_COMPLETE_MERGED_MAIN
+status: CURRENT_MAIN_RECONCILED_VISUAL_RUNTIME_COMPLETE
 current_work_router: docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
 image_goal_source: docs/visual/2026-08-26-remaining-image-goals.md
 codex_image_goal_source: docs/handoffs/2026-08-26-image-codex-integration-goals.md
@@ -40,9 +40,9 @@ The user has authorized automatic image creation and final registration for asse
 
 ## Completed image integration goals
 
-### CODEX-IMG-01 — Pet Cushion Runtime Surface Integration
+### CODEX-IMG-01 — Pet Cushion Runtime Surface Integration · Complete
 
-Waits for exactly:
+Integrated exact paths:
 
 ```text
 res://assets/images/decor/pet_cushion/cushion_stripe.png
@@ -52,9 +52,9 @@ res://assets/images/decor/pet_cushion/cushion_floral.png
 
 Three cosmetic visual variants of the existing `pet_cushion` meaning. No stat/rarity/cost/gacha/care/progression semantics.
 
-### CODEX-IMG-02 — Default Postcard Memory Face Integration
+### CODEX-IMG-02 — Default Postcard Memory Face Integration · Complete
 
-Waits for exactly:
+Integrated exact path:
 
 ```text
 res://assets/images/decor/postcard/postcard_boat_bright.png
@@ -98,7 +98,7 @@ Do not invent consumers to absorb extra art:
 - UI icons are deferred until a binding consumer/readability need exists.
 - app icon/store/marketing is P3 after release targets/branding lock.
 
-## Codex unpause gate
+## Completed integration receipt
 
 ```text
 IMG_01_3_FILES = IMPLEMENTATION_READY
@@ -111,7 +111,7 @@ CODEX_INTEGRATION_GOALS = CURRENT
 PR_19 = READ_ONLY_NO_ABSORPTION
 ```
 
-At Codex start, fresh-read current completed main, Project Notion, actual Godot files/tests, open PRs and toolchain. Use semantic TDD and runtime proof. GPT Work must stop before making Scene/Resource/GDScript product changes.
+At Codex start, fresh-read current completed main, Project Notion, actual Godot files/tests, open PRs and toolchain. Use semantic TDD and runtime proof for a newly approved product slice. GPT Work must stop before making Scene/Resource/GDScript product changes.
 
 ## Protected downstream scope
 
@@ -141,7 +141,7 @@ CODEX_IMG_02 = RUNTIME_VERIFIED_USER_APPROVED_MERGED_MAIN
 CODEX_LOCAL_WIRING_ASSETS = 4
 IMPLEMENTED_IMAGE_ASSETS = 4_MERGED_MAIN
 RUNTIME_VERIFIED_IMAGE_ASSETS = 4
-CI = GODOT_4_7_VALIDATION_PASS_RUN_155
+CI = GITHUB_GODOT_VALIDATION_PASS_PR_48_AND_PR_49
 FIRST_PRODUCTION_VISUAL_SLICE = CODEX_RUNTIME_CAPTURE_USER_APPROVED_MERGED_MAIN
 HANDPAINTED_3D_RUNTIME_SLICE = USER_APPROVED_MERGED_MAIN
 C_DOG_DEFAULT_RUNTIME_CAPTURE = PASS
@@ -168,8 +168,8 @@ FINAL_COMPOSITE_DECOR_RUNTIME_CAPTURE = PASS
 - `pet_cushion` keeps its existing base item ID and has only `stripe`, `moon`, and `floral` cosmetic appearances.
 - `postcard` keeps one default Bright Boat front face and no appearance selector or new collection/progression state.
 - `tests/test_runtime_image_asset_contract.gd` proves exact runtime texture paths, material consumers, fallback behavior, and core-state isolation.
-- Headless import, all 12 contracts, and all three scene smokes passed. Live 540×960 captures exist for Stripe, Moon, Floral, and Bright Boat postcard at `docs/evidence/2026-08-26-runtime-image-integration/`; editor diagnostics report 0 errors and the user approved the runtime review. The scoped integration is merged to `main` through PR #34 at merge commit `647e403bba4b9a537052d16963b469be10236be4`; GitHub Actions Godot 4.7 validation run #155 passed.
-- The First Production Visual Slice adds neutral avatar/non-species companion/boat `VisualStudy` layers, matte decor and ocean treatment, and compact Appreciation controls. Reproducible 540×960 Normal and Appreciation captures are at `docs/evidence/2026-08-26-first-production-visual-slice/`; these are runtime evidence only and await the user's 30-second/5-minute visual review.
+- Headless import, all current contract scripts, and all three scene smokes passed. Live 540×960 captures exist for Stripe, Moon, Floral, and Bright Boat postcard at `docs/evidence/2026-08-26-runtime-image-integration/`; editor diagnostics report 0 errors and the user approved the runtime review. The scoped integration is merged to `main` through PR #34 at merge commit `647e403bba4b9a537052d16963b469be10236be4`; later PRs #48 and #49 also passed GitHub Actions Godot 4.7 validation.
+- The First Production Visual Slice provided the bounded visual baseline. The user-approved C+dog final 2.5D route, cosmetic identity selection, four-time atmosphere, and final-composite decor correction now supersede it as the current runtime visual result. Reproducible 540×960 evidence remains technical proof; human/mobile comfort and touch review remain deferred.
 - The approved default direction is C knit/long-hair player + dog. Its bounded 3D proof keeps the current placeholder/care-free semantics and stores 540×960 Normal/Appreciation capture at `docs/evidence/2026-08-26-c-storybook-dog-default/`; the user approved it and it merged to `main` through PR #36 at merge commit `0e5f6c7c47d5b1415a3954b3fd6aee84ec17ff8f`. It remains below final art and real-device touch QA.
 - The final 2.5D storybook runtime set uses `assets/images/runtime/storybook/boat_c_dog_diorama_storybook.png` with `sea_bright_storybook.png`; Normal/Appreciation captures are at `docs/evidence/2026-08-26-final-2p5d-storybook-art/`. User approval, Notion final registration, SHA-256 provenance, and durable Git binary locators passed on 2026-08-26. Notion records: `MLB_FINAL_2P5D_C_DOG_BOAT_RUNTIME_V1` and `MLB_FINAL_2P5D_BRIGHT_SEA_RUNTIME_V1`.
 - `BoatDecorPersistence` stores only cosmetic `boat_decor` and `boat_decor_appearances` in `user://boat_decor_v1.cfg`. The service handles missing or wrong-typed data as an empty boat; no voyage, reward, affection, memory, camera, or social state is persisted. Automated local restore proof passes, while real-device QA remains deferred by user.


### PR DESCRIPTION
Closes #50\n\n## Scope\n- Reconciles README, roadmap, and current Godot handoff with completed visual/runtime work in main.\n- Restores the completed Stage 5 position and makes deferred human/mobile QA explicit.\n- Documents no gameplay, asset, social, or PR #19 changes.\n\n## Verification\n- Fresh-read origin/main at 2fb1ad9, GitHub PR state, Project Notion, and actual Godot structure.\n- Documentation diff check passes.\n- GitHub Godot validation will run on this PR.