### PR TITLE
Reconcile Phase 1 runtime canon

### DIFF
--- a/docs/CONCEPT.md
+++ b/docs/CONCEPT.md
@@ -45,11 +45,13 @@ Evidence boundary:
 ```text
 VISUAL_STYLE_DIRECTION = APPROVED
 DETAILED_VISUAL_STYLE_CANON = HANDPAINTED_STORYBOOK_3D_DIORAMA
-APPROVED_REPRESENTATIVE_VISUAL_GDD = NOT_YET_PRODUCED
-FINAL_AVATAR_ART = NOT_INTEGRATED
-FINAL_PET_ART = NOT_INTEGRATED
-FINAL_BOAT/SEA_ART = NOT_INTEGRATED
-HANDPAINTED_3D_RUNTIME_SLICE = NOT_RUN
+APPROVED_REPRESENTATIVE_VISUAL_GDD = CANCELLED_AS_REQUIRED_DELIVERABLE
+FINAL_AVATAR_ART = USER_APPROVED_NOTION_REGISTERED_LOCATOR_PASS
+FINAL_PET_ART = USER_APPROVED_NOTION_REGISTERED_LOCATOR_PASS
+FINAL_BOAT/SEA_ART = USER_APPROVED_NOTION_REGISTERED_LOCATOR_PASS
+HANDPAINTED_3D_RUNTIME_SLICE = USER_APPROVED_MERGED_MAIN
+FINAL_DECOR_ART = APPROVED_CUSHION_POSTCARD_RUNTIME_COMPOSITE_MERGED_MAIN
+APP_RESTART_DECOR_PERSISTENCE = AUTOMATED_LOCAL_RESTORE_PASS
 HUMAN_VISUAL_COMFORT_VALIDATION = NOT_RUN
 ```
 
@@ -75,7 +77,7 @@ HUMAN_VISUAL_COMFORT_VALIDATION = NOT_RUN
 
 ## 플레이어 경험
 
-플레이어는 오늘의 마음을 고르고 작은 보트 디오라마로 들어옵니다. 정상 화면에서는 자신의 기술용 Avatar, 펫, 보트와 바다가 함께 보입니다. 현재 구현 단계에서는 `PlayerAvatarPlaceholder`가 커스터마이즈 슬롯 계약만 제공하며 최종 아트가 아닙니다.
+플레이어는 오늘의 마음을 고르고 작은 보트 디오라마로 들어옵니다. 정상 화면에서는 자신의 Avatar, 펫, 보트와 바다가 함께 보입니다. `PlayerAvatarPlaceholder`는 계속 기술 layout shell을 제공하지만, 승인된 C+강아지 기본 합성과 로컬 외형 선택은 project-owned storybook runtime images를 실제 화면 소비처로 사용합니다. 이 통합은 Human/mobile comfort PASS가 아닙니다.
 
 `Appreciation Mode`를 켜면 기존 sea-focused 카메라가 활성화되고 대부분의 비필수 UI가 숨겨집니다. 이 전환은 항해 시간·보상·사운드스케이프를 바꾸지 않습니다. Appreciation Camera의 마우스/화면 드래그 입력은 해당 카메라가 실제 활성 상태일 때만 동작해 정상 디오라마 터치를 빼앗지 않습니다.
 
@@ -98,9 +100,9 @@ HUMAN_VISUAL_COMFORT_VALIDATION = NOT_RUN
 - `rail_accent`
 - `pet_corner`
 
-현재 starter decor는 `lantern / mug / cushion / plant / postcard / pet_cushion` 6종의 primitive technical placeholder입니다. 슬롯 호환성은 catalog가 소유하고, 유효하지 않은 배치는 저장 상태를 바꾸지 않습니다. 교체·비우기는 비용과 손실이 없습니다.
+현재 starter decor는 `lantern / mug / cushion / plant / postcard / pet_cushion` 6종입니다. base mesh는 기술 placeholder를 유지하지만 `pet_cushion`의 stripe/moon/floral 표면과 `postcard`의 Bright Boat face는 승인된 runtime visual consumer로 통합됐습니다. 슬롯 호환성은 catalog가 소유하고, 유효하지 않은 배치는 저장 상태를 바꾸지 않습니다. 교체·비우기는 비용과 손실이 없습니다.
 
-꾸미기 상태는 `GameState`에 `slot_id -> item_id`로 보관되어 **Scene 전환과 새 항해 동안 유지**되지만, 앱 종료/재실행을 넘는 save-file persistence는 아직 없습니다. 아이템에는 능력치·가격·희귀도 점수·재화·가챠·슬롯 완성 보너스가 없습니다.
+꾸미기 상태는 `GameState`의 `slot_id -> item_id` 의미를 유지하고, `BoatDecorPersistence`가 cosmetic decor와 appearance만 `user://boat_decor_v1.cfg`에 분리 저장해 앱 재시작 뒤에도 복원합니다. 아이템에는 능력치·가격·희귀도 점수·재화·가챠·슬롯 완성 보너스가 없습니다.
 
 ### Low-pressure Interaction
 
@@ -128,8 +130,8 @@ LOW_PRESSURE_INTERACTABLE = PASS
 BOAT_LIFE_TECH_UI = PASS
 DECOR_HUMAN_USABILITY = NOT_RUN
 REAL_MOBILE_DECOR_QA = NOT_RUN
-FINAL_DECOR_ART = NOT_INTEGRATED
-APP_RESTART_DECOR_PERSISTENCE = NOT_IMPLEMENTED
+FINAL_DECOR_ART = APPROVED_CUSHION_POSTCARD_RUNTIME_COMPOSITE_MERGED_MAIN
+APP_RESTART_DECOR_PERSISTENCE = AUTOMATED_LOCAL_RESTORE_PASS
 ```
 
 ## 승인된 다음 확장

--- a/docs/MVP_SCOPE.md
+++ b/docs/MVP_SCOPE.md
@@ -70,14 +70,14 @@ Human visual comfort와 실제 모바일 터치/구도는 `NOT_RUN`입니다.
 7. `rail_accent`
 8. `pet_corner`
 
-starter technical decor는 `lantern / mug / cushion / plant / postcard / pet_cushion`이다. 모두 Godot primitive mesh 기반 placeholder이며 final art가 아니다.
+starter technical decor는 `lantern / mug / cushion / plant / postcard / pet_cushion`이다. base mesh는 Godot primitive 기반 technical placeholder를 유지하지만, `pet_cushion`의 stripe/moon/floral 표면과 `postcard`의 Bright Boat face는 승인된 runtime visual consumer로 통합됐다.
 
 - 슬롯 호환성은 `BoatDecorCatalog`가 소유한다.
 - invalid placement는 저장 상태를 바꾸지 않는다.
 - replace/clear는 비용·손실이 없다.
 - 가격, 재화, 능력치, rarity score, gacha, fill bonus, daily-shop FOMO가 없다.
-- `GameState.boat_decor`는 `slot_id -> item_id`만 저장한다.
-- Scene 전환과 새 항해에는 유지되지만 앱 재시작 persistence는 아직 없다.
+- `GameState.boat_decor`는 `slot_id -> item_id` 의미를 유지하고, cosmetic decor와 appearance는 `BoatDecorPersistence`가 별도 로컬 config에 저장한다.
+- Scene 전환·새 항해·앱 재시작 뒤에도 자동 로컬 복원으로 유지된다.
 
 ### Low-pressure Interactable
 
@@ -115,14 +115,14 @@ BOAT_LIFE_TECH_UI = PASS
 ```text
 DECOR_HUMAN_USABILITY = NOT_RUN
 REAL_MOBILE_DECOR_QA = NOT_RUN
-FINAL_DECOR_ART = NOT_INTEGRATED
-APP_RESTART_DECOR_PERSISTENCE = NOT_IMPLEMENTED
+FINAL_DECOR_ART = APPROVED_CUSHION_POSTCARD_RUNTIME_COMPOSITE_MERGED_MAIN
+APP_RESTART_DECOR_PERSISTENCE = AUTOMATED_LOCAL_RESTORE_PASS
 ```
 
 ## Resting Core Technical Prototype
 
 - persistent `RestingSoundscape` AutoLoad
-- generated 4초 `AudioStreamWAV` OceanBed / `-16 dB` / loop
+- generated 16초 stereo `AudioStreamWAV` OceanBed / `-18 dB` / loop
 - `RestingPetPlaceholder` 12~24초 저밀도 idle / care obligation 없음
 - soft ocean/light/mood-sky 기술 ceiling
 
@@ -165,7 +165,7 @@ APP_RESTART_DECOR_PERSISTENCE = NOT_IMPLEMENTED
 - 안정적인 수평선과 낮은 시각 자극
 - Avatar/Pet/Decor가 한 화면에 있지만 바다를 가리지 않는 구도
 
-현재 Avatar/Pet/Decor/Sea는 technical placeholder이며 최종 Visual PASS가 아니다.
+승인된 C+강아지 보트/바다 route, 로컬 플레이어·펫 외형 카드, 펫 방석 3종, Bright Boat 엽서 face는 runtime에 통합됐다. base 3D shell과 일부 starter mesh는 technical placeholder를 유지하며, Human/mobile Visual PASS는 아직 아니다.
 
 ## 우선 플랫폼
 
@@ -176,9 +176,9 @@ APP_RESTART_DECOR_PERSISTENCE = NOT_IMPLEMENTED
 
 ## 현재 의도적으로 미포함
 
-- 앱 재실행을 넘는 save-file persistence
+- 앱 재실행 persistence의 실제 모바일 Human QA
 - 자유배치 3D decor editor / 직접 3D drag placement
-- 제작 아바타/펫/보트/장식/바다 최종 아트
+- 승인된 runtime art를 넘어서는 새 avatar/pet/boat/decor/sea asset 제작
 - production 자연 오디오
 - FriendBottle / DriftBottle runtime
 - Supabase Auth / DB / RLS / Edge Functions

--- a/docs/handoffs/2026-08-27-work-five-phase-current-slice.md
+++ b/docs/handoffs/2026-08-27-work-five-phase-current-slice.md
@@ -1,0 +1,61 @@
+# Work 5단계 현재 Slice 정합성 Receipt
+
+> 이 문서는 사람용 프로젝트 정본이나 새 제품 요구사항이 아니다. Base 5단계 실행 계약을 현재 `main`의 승인된 rest-first runtime에 매핑한 실행 receipt다.
+
+## Identity
+
+```yaml
+project: MY_LITTLE_BOAT
+current_completed_main: 2df685aa110670979b3a01dc26a6583650210efc
+product_identity: REST_FIRST_VISUAL_RUNTIME_AUTOMATION_CLOSEOUT
+notion_home: 3c41b237-eb1c-8194-8b8e-d88362cafafa
+current_router: docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
+protected_open_workstream: PR_19_READ_ONLY_NO_ABSORPTION
+human_usability_evidence: NOT_RUN
+player_experience_evidence: NOT_RUN
+```
+
+## Reconfirmed player contract
+
+- Player promise: visible avatar, pet, personal boat, decor, and sea provide a rest-first 3/4 diorama where doing nothing remains valid.
+- Core loop: choose today’s mood → rest or optionally interact/decorate/fish/discover → make a voyage memory → remain or begin another voyage.
+- Meaningful choice: mood, cosmetic identity, four-time atmosphere, decor appearance, and optional low-pressure activities alter presentation or expression, never rewards, pressure, or failure.
+- Reward and failure learning: personal memory, scenery, companion affection, and boat traces; no combat, loss, streak, farming, or care-obligation failure.
+
+## Evidence-based SWOT
+
+| Lens | Current evidence | Execution implication |
+| --- | --- | --- |
+| Strength | approved C+dog visual route, local identity/decor appearance, four-time atmosphere, and runtime image contracts are merged | preserve current visual consumers rather than recreate art |
+| Weakness | no export preset or durable internal user build; Human/mobile/audio quality remains `NOT_RUN` | do not call the slice user-ready until a package path and exact-build smoke exist |
+| Opportunity | existing 540×960 runtime evidence and Godot contract suite support a bounded internal-build closeout | evaluate a low-risk package path before new gameplay or asset scope |
+| Threat | stale canon can route work toward already-completed image production; PR #19 is independent | maintain a single current router and keep PR #19 read-only |
+
+## Five-phase mapping
+
+| Work phase | Project-native evidence | Status |
+| --- | --- | --- |
+| Phase 1 · Planning co-design | approved rest-first direction, visual language, local-first rules, C+dog default, cosmetic identity, decor and atmosphere decisions | `RECONFIRMED_AFTER_CANON_CORRECTION` |
+| Phase 2 · Preproduction review | no internal user-build target or export/package contract exists yet | `NEXT_REQUIRED_PHASE` |
+| Phase 3 · In-game element production | required P1 cushion/postcard and C+dog/runtime visual inputs are already project-local, registered, and consumed | `COMPLETE_FOR_CURRENT_VISUAL_SCOPE` |
+| Phase 4 · Codex implementation and machine closeout | Godot contracts and scene smokes exist; a current exact-build package, clean extract/launch smoke, and user-validation packet do not | `INCOMPLETE_CLOSEOUT` |
+| Phase 5 · User vertical-slice validation | user has not played an exact packaged build | `NOT_STARTED` |
+
+## Approved scope for the next review
+
+```text
+IN_SCOPE
+- Reconcile stale repository/Notion status with actual merged runtime evidence.
+- Review a zero-cost internal package route for the existing runtime without changing gameplay or art direction.
+- Preserve deterministic and runtime validation evidence.
+
+OUT_OF_SCOPE
+- New gameplay, economy, progression, social integration, asset families, paid tools, public release, store publication, or PR #19 changes.
+
+PROTECTED
+- rest-first loop, local-first core, visual reference lock, camera semantics, decor IDs, cosmetic-only meaning, and delayed-bottle safety boundary.
+```
+
+## Next safe action
+
+Phase 2 will compare internal package routes against the current Windows host, existing Godot 4.7 project settings, mobile-first presentation, and zero-cost constraint. It must select or defer a route before creating export settings or claiming `AUTOMATED_VERTICAL_SLICE_READY`.

--- a/docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
+++ b/docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
@@ -9,6 +9,7 @@ project: MY_LITTLE_BOAT
 mode: CODEX_GODOT_PRODUCT_IMPLEMENTATION_HANDOFF
 status: CURRENT_MAIN_RECONCILED_VISUAL_RUNTIME_COMPLETE
 current_work_router: docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
+five_phase_execution_receipt: docs/handoffs/2026-08-27-work-five-phase-current-slice.md
 image_goal_source: docs/visual/2026-08-26-remaining-image-goals.md
 codex_image_goal_source: docs/handoffs/2026-08-26-image-codex-integration-goals.md
 image_asset_policy: CONSUMER_FIRST_ASSET

--- a/docs/handoffs/CURRENT_GPT_WORK.md
+++ b/docs/handoffs/CURRENT_GPT_WORK.md
@@ -1,17 +1,17 @@
-# Current GPT Work Closeout
+# Historical GPT Work Closeout
 
-> The GPT Work image-production phase is closed. This file preserves its result; continue product work from `docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md`.
+> The GPT Work image-production phase is closed and its Codex integration is complete on `main`. This file preserves the pre-integration production receipt; use `docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md` for current product work.
 
 ```yaml
 project: MY_LITTLE_BOAT
 mode: GPT_WORK_IMAGE_PRODUCTION_CLOSEOUT
-status: COMPLETE_READY_FOR_CODEX_IMAGE_INTEGRATION
+status: HISTORICAL_SUPERSEDED_BY_CODEX_IMAGE_INTEGRATION
 current_owner: CODEX_GODOT_PRODUCT_IMPLEMENTATION_OWNER
 handoff_packet: docs/handoffs/2026-08-26-gpt-work-image-production-handoff.md
 image_goal_queue: docs/visual/2026-08-26-remaining-image-goals.md
 consumer_manifest: docs/visual/2026-08-26-game-image-consumer-manifest.md
 codex_integration_goals: docs/handoffs/2026-08-26-image-codex-integration-goals.md
-codex_product_build: IMAGE_INTEGRATION_READY
+codex_product_build: IMAGE_INTEGRATION_COMPLETE_MERGED_MAIN
 concurrent_pr_19: READ_ONLY_NO_ABSORPTION
 ```
 
@@ -68,8 +68,8 @@ IMG_01 = 3 IMPLEMENTATION_READY files + Notion readback PASS
 IMG_02 = 1 IMPLEMENTATION_READY file + Notion readback PASS
 DURABLE_BINARY_LOCATORS = PASS
 DEFERRED_SCOPE = UNCHANGED
-CURRENT_GODOT_IMPLEMENTATION = READY_FOR_CODEX_IMAGE_INTEGRATION
+CURRENT_GODOT_IMPLEMENTATION = CODEX_IMAGE_INTEGRATION_COMPLETE_MERGED_MAIN
 GODOT_PRODUCT_CHANGES_BY_GPT_WORK = 0
 ```
 
-All conditions above are satisfied. `IMPLEMENTED` and `RUNTIME_VERIFIED` remain Codex-owned and are not claimed by this closeout.
+All conditions above are satisfied. This historical closeout does not itself claim Codex implementation; current `IMPLEMENTED` and `RUNTIME_VERIFIED` evidence is owned by `CURRENT_GODOT_IMPLEMENTATION.md`.

--- a/docs/handoffs/CURRENT_PLANNING_VISUAL_WORK.md
+++ b/docs/handoffs/CURRENT_PLANNING_VISUAL_WORK.md
@@ -1,6 +1,6 @@
-# Current Planning & Visual Work
+# Historical Planning & Visual Work Closeout
 
-> The approved noncoding image-production phase is complete. Continue with Codex image integration through `docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md`.
+> The approved noncoding image-production phase and its Codex integration are complete on `main`. This file preserves the pre-integration planning receipt; continue current product work through `docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md`.
 
 ## Current state
 
@@ -9,11 +9,11 @@ project: MY_LITTLE_BOAT
 mode: GPT_WORK_IMAGE_PRODUCTION_CLOSEOUT
 current_owner: CODEX_GODOT_PRODUCT_IMPLEMENTATION_OWNER
 policy: CONSUMER_FIRST_ASSET
-status: COMPLETE_READY_FOR_CODEX_IMAGE_INTEGRATION
+status: HISTORICAL_SUPERSEDED_BY_CODEX_IMAGE_INTEGRATION
 current_work_router: docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
 handoff_packet: docs/handoffs/2026-08-26-gpt-work-image-production-handoff.md
 concurrent_pr_19: READ_ONLY_NO_ABSORPTION
-codex_product_build: IMAGE_INTEGRATION_READY
+codex_product_build: IMAGE_INTEGRATION_COMPLETE_MERGED_MAIN
 ```
 
 The four required runtime files have user approval, Asset Library readback, and durable binary locator PASS. GPT Work made no Godot Scene, Resource, or GDScript product change.
@@ -59,13 +59,13 @@ IMG_01_NOTION_READBACK = PASS
 IMG_02 = 1 IMPLEMENTATION_READY file
 IMG_02_NOTION_READBACK = PASS
 DURABLE_BINARY_LOCATORS = PASS
-CODEX_ROUTER = READY_FOR_CODEX_IMAGE_INTEGRATION
+CODEX_ROUTER = CODEX_IMAGE_INTEGRATION_COMPLETE_MERGED_MAIN
 GODOT_PRODUCT_CHANGES_BY_GPT_WORK = 0
 ```
 
 The gate is satisfied. Codex must still perform import, wiring, and runtime proof; GPT Work must not do those tasks.
 
-Until Codex has performed that downstream work, GPT Work must:
+Historical pre-integration boundary retained for provenance:
 
 - not start Godot product implementation;
 - not claim runtime verification;
@@ -78,9 +78,9 @@ Until Codex has performed that downstream work, GPT Work must:
 GOAL_QUEUE = USER_APPROVED
 ACTIVE_P1_REQUIRED_FILES = 4
 IMPLEMENTATION_READY_IMAGE_ASSETS = 4
-IMPLEMENTED_IMAGE_ASSETS = 0
-RUNTIME_VERIFIED_IMAGE_ASSETS = 0
+IMPLEMENTED_IMAGE_ASSETS = HISTORICAL_PRE_INTEGRATION_VALUE_0
+RUNTIME_VERIFIED_IMAGE_ASSETS = HISTORICAL_PRE_INTEGRATION_VALUE_0
 GPT_WORK_IMAGE_PRODUCTION = COMPLETE
-CODEX_IMAGE_INTEGRATION = READY_TO_START
-GODOT_RUNTIME = NOT_RUN
+CODEX_IMAGE_INTEGRATION = HISTORICAL_READY_TO_START
+GODOT_RUNTIME = HISTORICAL_NOT_RUN
 ```

--- a/docs/learning/2026-08-27-phase1-canon-drift-reconciliation.md
+++ b/docs/learning/2026-08-27-phase1-canon-drift-reconciliation.md
@@ -1,0 +1,24 @@
+# Phase 1 Canon Drift Reconciliation Lesson
+
+## Incident
+
+The current Godot router, README, merged runtime assets, and executed Godot contracts showed completed C+dog, runtime image, decor persistence, four-time atmosphere, and final-composite work. Active repository mirrors and the Notion Visual Bible still contained pre-integration `NOT_INTEGRATED`, `NOT_IMPLEMENTED`, and `READY_FOR_CODEX_IMAGE_INTEGRATION` states.
+
+## Root cause
+
+The visual implementation was merged through several scoped PRs after the original Work image-production closeout. Historical closeout documents remained discoverable as current-looking routers, and status propagation to every active mirror was incomplete.
+
+## Solution and evidence
+
+- Reclassified the two pre-integration Work handoffs as historical and directed current work to `CURRENT_GODOT_IMPLEMENTATION.md`.
+- Reconciled `CONCEPT.md` and `MVP_SCOPE.md` with the merged runtime facts while retaining all Human/mobile evidence as `NOT_RUN`.
+- Updated the Notion Visual Bible’s runtime-status and current-execution lines, then completed destination readback.
+- Kept PR #19 open and unmodified.
+
+## Recurrence guard
+
+Before beginning a new Phase 2 or Codex window, compare every current-looking router with the actual completed `main` runtime evidence. Historical receipts may preserve old values only when their title and status make the historical boundary explicit.
+
+## Base promotion disposition
+
+`NO_BASE_PROMOTION`. Base already owns the reusable rule through `WORK_EXECUTION_EVIDENCE_IDENTITY_INTEGRITY`, including product baseline versus router-sync identity separation and historical evidence boundaries. This project-specific correction adds no new general rule.


### PR DESCRIPTION
## Summary
- reconciles active repository and Notion-facing runtime status with current merged evidence
- marks pre-integration GPT/visual handoffs as historical rather than active routing sources
- records the five-phase slice position, incident/solution/lesson, and next Phase 2 packaging decision

Closes #56

## Verification
- targeted repository canon assertions passed
- `git diff --check` passed for the seven documentation files
- current `origin/main` Godot contract suite and three scene smokes completed with exit code 0 before this documentation-only change

## Scope boundary
- documentation and Notion canon reconciliation only
- no Godot scene/resource/GDScript/runtime asset changes
- PR #19 remains read-only and unabsorbed