### PR TITLE
Clarify historical image handoff

### DIFF
--- a/docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
+++ b/docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
@@ -32,7 +32,7 @@ RUNTIME_CONSUMER_OR_CLEAR_VISUAL_NEED
 → project-local binary storage
 → Notion final asset registration + durable binary locator
 → IMPLEMENTATION_READY
-→ GPT Work changes this router to READY_FOR_CODEX_IMAGE_INTEGRATION
+→ GPT Work historical pre-integration handoff
 → CODEX-IMG-01 / CODEX-IMG-02
 → Godot import/wiring/runtime proof
 → GPT final implementation review


### PR DESCRIPTION
## Summary
- replaces the active router’s stale pre-integration state label with an explicit historical-handoff label
- adds no gameplay, asset, workflow, package, social, or PR #19 change

Closes #62

## Regression evidence
- active-router drift assertion now rejects `READY_FOR_CODEX_IMAGE_INTEGRATION`
- current package PASS and Human QA NOT_RUN boundaries remain intact