### PR TITLE
Document generated WAV shutdown baseline

### DIFF
--- a/docs/learning/2026-08-27-generated-wav-shutdown-baseline.md
+++ b/docs/learning/2026-08-27-generated-wav-shutdown-baseline.md
@@ -1,0 +1,24 @@
+# Generated WAV Shutdown Baseline Lesson
+
+## Incident
+
+Local Godot 4.7.2 headless quit for the current project exited `0` but reported one `AudioStreamWAV` and one `AudioStreamPlaybackWAV` ObjectDB leak.
+
+## Investigation
+
+- The project warning was reproduced after the persistent authored ocean bed was initialized.
+- Stopping, clearing, and explicitly freeing its `AudioStreamPlayer` did not remove the two leak lines.
+- A temporary empty Godot 4.7.2 project exited without warnings.
+- The same temporary project, containing only a generated `AudioStreamWAV`, one `AudioStreamPlayer`, `play()`, `stop()`, and `free()`, reproduced exactly the same two leak lines and still exited `0`.
+
+## Disposition
+
+This is a Godot 4.7.2 generated-WAV shutdown baseline, not a project-owned leak. No production script, scene, resource, asset, or workflow change is warranted. The trial cleanup and its test were removed before commit.
+
+## Recurrence guard
+
+When a local engine shutdown warning appears after a generated-audio change, first reproduce it in a minimal project on the same engine version. Do not alter project lifecycle code merely to hide an engine-level exit diagnostic. Treat nonzero exit, user-visible runtime failure, or a project-only reproduction as a separate actionable incident.
+
+## Base promotion disposition
+
+`NO_BASE_PROMOTION`. The adopted Base debugging contract already requires a root-cause reproduction before a fix. This is a version-specific Godot observation rather than a reusable workflow rule.


### PR DESCRIPTION
## Summary
- records the local Godot 4.7.2 generated-WAV shutdown warning investigation
- preserves the finding that it reproduces in a minimal generated-audio project and is not project-owned
- confirms no production script, test, scene, resource, asset, or workflow change remains

## Validation
- focused `test_resting_core_contract.gd` passes with the original project behavior
- local headless quit exits `0`
- trial code/test changes were removed before commit

## Boundary
- generated WAV shutdown warning is recorded as an engine-version baseline, not hidden by lifecycle changes
- PR #19 remains untouched

Closes #66