### PR TITLE
Reconcile album completion handoff

### DIFF
--- a/docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
+++ b/docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
@@ -1,13 +1,13 @@
 # Current Godot Product Implementation
 
-> **CODEX IMAGE INTEGRATION COMPLETE.** The approved runtime images and P0 main-entry composition are merged into `main`, have passed GitHub Godot validation, and retain 540×960 runtime proof.
+> **CODEX IMAGE INTEGRATION COMPLETE.** The approved runtime images, P0 main-entry composition, and P1 album composition are merged into `main`, have passed GitHub Godot validation, and retain 540×960 runtime proof.
 
 ## Current state
 
 ```yaml
 project: MY_LITTLE_BOAT
 mode: CODEX_GODOT_PRODUCT_IMPLEMENTATION_HANDOFF
-status: CURRENT_MAIN_RECONCILED_P0_MAIN_ENTRY_COMPOSITION_COMPLETE
+status: CURRENT_MAIN_RECONCILED_P0_MAIN_ENTRY_AND_P1_ALBUM_COMPOSITION_COMPLETE
 current_work_router: docs/handoffs/CURRENT_GODOT_IMPLEMENTATION.md
 screen_surface_coverage_owner: docs/visual/CURRENT_SCREEN_SURFACE_INVENTORY_AND_VISUAL_ASSET_COVERAGE.md
 five_phase_execution_receipt: docs/handoffs/2026-08-27-work-five-phase-current-slice.md
@@ -29,7 +29,7 @@ visual_reference_lock: HANDPAINTED_STORYBOOK_3D_DIORAMA
 The current runtime-image and diorama integration remains complete. A fresh whole-screen audit now owns the next visual product decision at `docs/visual/CURRENT_SCREEN_SURFACE_INVENTORY_AND_VISUAL_ASSET_COVERAGE.md`.
 
 - `MLB-SCR-001` main entry is complete on `main` through [Issue #71](https://github.com/alsdmlals4-eng/MylittleBoat/issues/71) and [PR #72](https://github.com/alsdmlals4-eng/MylittleBoat/pull/72), merge commit `7a107873c49cb289fe9f4bc02bcda1c065f8d6e3`. `AtmosphereBackground` selects the approved 1024×1536 file for each time choice, `DioramaAnchor` presents the approved C+dog boat anchor, and compact Godot UI controls preserve identity, light, mood, and route semantics. Four 540×960 runtime captures, the focused contract, all existing contracts, three scene smokes, and GitHub validation passed.
-- `MLB-SCR-010` album composition is implemented in active Issue [#75](https://github.com/alsdmlals4-eng/MylittleBoat/issues/75). It uses Godot UI/text, the selected approved atmosphere background, and actual record text; it adds no authored fake album images. Empty and populated 540×960 captures plus focused contracts are in the branch before merge.
+- `MLB-SCR-010` album composition is complete on `main` through [Issue #75](https://github.com/alsdmlals4-eng/MylittleBoat/issues/75) and [PR #76](https://github.com/alsdmlals4-eng/MylittleBoat/pull/76), merge commit `69a2a7f2fdbfc251cfb6d4a3f446ab39dd080cbc`. It uses Godot UI/text, the selected approved atmosphere background, and actual record text; it adds no authored fake album images. Empty and populated 540×960 captures, focused contracts, full test suite, three scene smokes, and GitHub validation passed.
 - Main-menu atmosphere backgrounds are the only post-audit bitmap family approved by the user's explicit 2026-08-28 request. No UI icon, portrait-only, UV texture, album filler, or other image family is implied.
 - The screen inventory now uses the required screen × object × state × variation fields and confirms no other current runtime image family is missing. PR #19 remains `READ_ONLY_NO_ABSORPTION`.
 

--- a/docs/visual/CURRENT_SCREEN_SURFACE_INVENTORY_AND_VISUAL_ASSET_COVERAGE.md
+++ b/docs/visual/CURRENT_SCREEN_SURFACE_INVENTORY_AND_VISUAL_ASSET_COVERAGE.md
@@ -141,7 +141,7 @@ The implementation uses the exact four approved background files through `Atmosp
 
 ### P1 follow-up completion
 
-- `MLB-SCR-010` is completed by Issue #75 pending its main merge. It reuses actual record text and the approved atmosphere background family; no album art or presentation-only photos were created.
+- `MLB-SCR-010` is complete on `main` through [Issue #75](https://github.com/alsdmlals4-eng/MylittleBoat/issues/75) and [PR #76](https://github.com/alsdmlals4-eng/MylittleBoat/pull/76), merge commit `69a2a7f2fdbfc251cfb6d4a3f446ab39dd080cbc`. It reuses actual record text and the approved atmosphere background family; no album art or presentation-only photos were created.
 
 ### Acceptance
 


### PR DESCRIPTION
## Goal
Correct the current handoff and visual inventory now that the album PR is merged.

## Included
- Records Issue #75, PR #76, and its main merge commit as completed.
- Removes obsolete pre-merge wording.
- Preserves the PR #19 read-only/no-absorption boundary.

## Verification
- Documentation-only diff reviewed with `git diff --check`.

Closes #77